### PR TITLE
Add support for Docker instead of Containerd

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -35,12 +35,15 @@ func MakeInstall() *cobra.Command {
 	command.Flags().Int("ssh-port", 22, "The port on which to connect for ssh")
 	command.Flags().Bool("skip-install", false, "Skip the k3s installer")
 	command.Flags().String("local-path", "kubeconfig", "Local path to save the kubeconfig file")
+	command.Flags().Bool("docker", false, "Use Docker instead of Containerd")
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 
 		localKubeconfig, _ := command.Flags().GetString("local-path")
 
 		skipInstall, _ := command.Flags().GetBool("skip-install")
+
+		useDocker, _ := command.Flags().GetBool("docker")
 
 		port, _ := command.Flags().GetInt("ssh-port")
 
@@ -78,7 +81,13 @@ func MakeInstall() *cobra.Command {
 		defer operator.Close()
 
 		if !skipInstall {
-			installK3scommand := fmt.Sprintf("curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --tls-san %s' sh -\n", ip)
+			if !useDocker {
+				installK3scommand := fmt.Sprintf("curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --tls-san %s' sh -\n", ip)
+			}
+			else {
+				installK3scommand := fmt.Sprintf("curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --docker --tls-san %s' sh -\n", ip)
+			}
+
 			fmt.Printf("ssh: %s\n", installK3scommand)
 			res, err := operator.Execute(installK3scommand)
 

--- a/pkg/cmd/join.go
+++ b/pkg/cmd/join.go
@@ -28,6 +28,7 @@ func MakeJoin() *cobra.Command {
 	command.Flags().String("ssh-key", "~/.ssh/id_rsa", "The ssh key to use for remote login")
 	command.Flags().Int("ssh-port", 22, "The port on which to connect for ssh")
 	command.Flags().Bool("skip-install", false, "Skip the k3s installer")
+	command.Flags().Bool("docker", false, "Use Docker instead of Containerd")
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 
@@ -136,7 +137,13 @@ func setupAgent(serverIP, ip net.IP, port int, user, sshKeyPath, joinToken strin
 
 	defer operator.Close()
 
-	getTokenCommand := fmt.Sprintf(`curl -sfL https://get.k3s.io/ | K3S_URL="https://%s:6443" K3S_TOKEN="%s" sh -`, serverIP.String(), strings.TrimSpace(joinToken))
+	if !useDocker {
+		getTokenCommand := fmt.Sprintf(`curl -sfL https://get.k3s.io/ | K3S_URL="https://%s:6443" K3S_TOKEN="%s" sh -`, serverIP.String(), strings.TrimSpace(joinToken))
+	}
+	else {
+		getTokenCommand := fmt.Sprintf(`curl -sfL https://get.k3s.io/ | INSTALL_K3S_EXEC="--docker" K3S_URL="https://%s:6443" K3S_TOKEN="%s" sh -`, serverIP.String(), strings.TrimSpace(joinToken))
+	}
+	
 	fmt.Printf("ssh: %s\n", getTokenCommand)
 
 	res, err := operator.Execute(getTokenCommand)


### PR DESCRIPTION
## Description
Add flag to support the K3S Feature tu use Docker instead of Containerd.
Refer to #16 for more details.

## How Has This Been Tested?
Not tested, but it should work as it is not a major change in the code (6 lines modified).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

