### PR TITLE
Missing "install" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ In a few moments you will have Kubernetes up and running on your Raspberry Pi 2,
 
 * Copy over your ssh key with: `ssh-copy-id pi@raspberrypi.local`
 
-* Run `k3sup --ip $IP --user pi`
+* Run `k3sup install --ip $IP --user pi`
 
 * Point at the config file and get the status of the node:
 


### PR DESCRIPTION
The install command is missing in the instruction for raspberryPi

## Description
Added the proper instruction to install

## Motivation and Context


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
