### PR TITLE
Add ability to specify extra arguments to k3s

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Other options for `install`:
 * `--ssh-key` - specify a specific path for the SSH key for remote login
 * `--local-path` - default is `./kubeconfig` - set the path into which you want to save your VM's `kubeconfig`
 * `--ssh-port` - default is `22`, but you can specify an alternative port i.e. `2222`
+* `--k3s-extra-args` - Optional extra arguments to pass to k3s installer, wrapped in quotes, i.e. `--k3s-extra-args '--docker --no-deploy servicelb'`
 
 * Now try the access:
 

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -38,6 +38,7 @@ func MakeInstall() *cobra.Command {
 	command.Flags().Int("ssh-port", 22, "The port on which to connect for ssh")
 	command.Flags().Bool("skip-install", false, "Skip the k3s installer")
 	command.Flags().String("local-path", "kubeconfig", "Local path to save the kubeconfig file")
+	command.Flags().String("k3s-extra-args", "", "Optional extra arguments to pass to k3s installer, wrapped in quotes (e.g. --k3s-extra-args '--no-deploy servicelb')")
 	command.Flags().Bool("merge", false, "Merge the config with existing kubeconfig if it already exists.\nProvide the --local-path flag with --merge if a kubeconfig already exists in some other directory")
 
 	command.RunE = func(command *cobra.Command, args []string) error {
@@ -54,6 +55,7 @@ func MakeInstall() *cobra.Command {
 		user, _ := command.Flags().GetString("user")
 		sshKey, _ := command.Flags().GetString("ssh-key")
 		merge, _ := command.Flags().GetBool("merge")
+		k3sExtraArgs, _ := command.Flags().GetString("k3s-extra-args")
 
 		sshKeyPath := expandPath(sshKey)
 		fmt.Printf("ssh -i %s %s@%s\n", sshKeyPath, user, ip.String())
@@ -83,7 +85,7 @@ func MakeInstall() *cobra.Command {
 		defer operator.Close()
 
 		if !skipInstall {
-			installK3scommand := fmt.Sprintf("curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --tls-san %s' sh -\n", ip)
+			installK3scommand := fmt.Sprintf("curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --tls-san %s %s' sh -\n", ip, k3sExtraArgs)
 			fmt.Printf("ssh: %s\n", installK3scommand)
 			res, err := operator.Execute(installK3scommand)
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Add ability to specify extra arguments to k3s

## Motivation and Context

As a user of k3sup,
I want to be able to specify additional k3s install options (such as --no-deploy, --node-taint, etc),
So that I can continue to leverage k3sup but have some control over the way k3s is installed or joined

Fixes #21
Fixes #16
Achieves what #19 is aiming to do, too

- [x] I have raised an issue to propose this change ([required])

## How Has This Been Tested?
Built locally, and tested by way of running `k3sup` with or without this new argument in different ways:

* Ran k3sup without reference to the new argument to ensure that it still works as expected (i.e. this change didn't break existing functionality) - **pass**
* Ran k3sup with the new argument at the end of the argument list - **pass**
* Ran k3sup with the new argument in the middle of the argument list - **pass**
* Ran k3sup with the new argument referencing multiple k3s options - **pass**
* Ran k3sup with the new argument _not_ referencing the options wrapped in quotes - **fail** (expected result as Cobra Command can't know which arguments are meant for the program itself vs to pass along)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

