### PR TITLE
allow joins to work properly with k3sExtraArgs

### DIFF
--- a/pkg/cmd/join.go
+++ b/pkg/cmd/join.go
@@ -139,7 +139,7 @@ func setupAgent(serverIP, ip net.IP, port int, user, sshKeyPath, joinToken strin
 
 	defer operator.Close()
 
-	getTokenCommand := fmt.Sprintf(`curl -sfL https://get.k3s.io/ | K3S_URL="https://%s:6443" K3S_TOKEN="%s" sh - %s`, serverIP.String(), strings.TrimSpace(joinToken), k3sExtraArgs)
+	getTokenCommand := fmt.Sprintf("curl -sfL https://get.k3s.io/ | K3S_URL='https://%s:6443' K3S_TOKEN='%s' sh -s - %s", serverIP.String(), strings.TrimSpace(joinToken), k3sExtraArgs)
 	fmt.Printf("ssh: %s\n", getTokenCommand)
 
 	res, err := operator.Execute(getTokenCommand)


### PR DESCRIPTION
## Description
Using the `--k3s-extra-args` command-line argument failed during a join operation.

## Motivation and Context
Fixes #30 

## How Has This Been Tested?

Reproduced the issue,

```shell
➜ k3sup join --ip 10.2.0.31 --server-ip 10.2.0.30 --user ubuntu --k3s-extra-args '--docker'
Server IP: 10.2.0.30
ssh -i /Users/jeff/.ssh/id_rsa ubuntu@10.2.0.30
ssh: sudo cat /var/lib/rancher/k3s/server/node-token

<redacted>
ssh: curl -sfL https://get.k3s.io/ | K3S_URL="https://10.2.0.30:6443" K3S_TOKEN="<redacted>" sh - --docker
sh: 0: Can't open --docker
```

After correcting the issue, 

1. validated that the normal behavior (without specifying the `--k3s-extra-args` argument) still works as expected:

```shell
➜ bin/k3sup-darwin join --ip 10.2.0.31 --server-ip 10.2.0.30 --user ubuntu                            
Server IP: 10.2.0.30
ssh -i /Users/jeff/.ssh/id_rsa ubuntu@10.2.0.30
ssh: sudo cat /var/lib/rancher/k3s/server/node-token

<redacted>
ssh: curl -sfL https://get.k3s.io/ | K3S_URL='https://10.2.0.30:6443' K3S_TOKEN='<redacted>' sh -s - 
[INFO]  Finding latest release
...
```

2. validated that the `--k3s-extra-args` behavior now works:

```shell
➜ bin/k3sup-darwin join --ip 10.2.0.31 --server-ip 10.2.0.30 --user ubuntu --k3s-extra-args '--docker'
Server IP: 10.2.0.30
ssh -i /Users/jeff/.ssh/id_rsa ubuntu@10.2.0.30
ssh: sudo cat /var/lib/rancher/k3s/server/node-token

<redacted>
ssh: curl -sfL https://get.k3s.io/ | K3S_URL='https://10.2.0.30:6443' K3S_TOKEN='<redacted>' sh -s - --docker
[INFO]  Finding latest release
...
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
