### PR TITLE
add support for k3s extra environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Other options for `install`:
 * `--local-path` - default is `./kubeconfig` - set the path into which you want to save your VM's `kubeconfig`
 * `--ssh-port` - default is `22`, but you can specify an alternative port i.e. `2222`
 * `--k3s-extra-args` - Optional extra arguments to pass to k3s installer, wrapped in quotes, i.e. `--k3s-extra-args '--docker --no-deploy servicelb'`
+* `--k3s-extra-envs` - Optional extra arguments to pass to the k3s installer, wrapped in quotes, i.e. `--k3s-extra-envs 'INSTALL_K3S_VERSION=vX.Y.Z'`
 
 * Now try the access:
 

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -39,6 +39,7 @@ func MakeInstall() *cobra.Command {
 	command.Flags().Bool("skip-install", false, "Skip the k3s installer")
 	command.Flags().String("local-path", "kubeconfig", "Local path to save the kubeconfig file")
 	command.Flags().String("k3s-extra-args", "", "Optional extra arguments to pass to k3s installer, wrapped in quotes (e.g. --k3s-extra-args '--no-deploy servicelb')")
+	command.Flags().String("k3s-extra-envs", "", "Optional exta environment variables to pass to k3s installer, wrapped in quotes (e.g. --k3s-extra-envs 'INSTALL_K3S_VERSION=vX.Y.Z-rc')")
 	command.Flags().Bool("merge", false, "Merge the config with existing kubeconfig if it already exists.\nProvide the --local-path flag with --merge if a kubeconfig already exists in some other directory")
 
 	command.RunE = func(command *cobra.Command, args []string) error {
@@ -56,6 +57,7 @@ func MakeInstall() *cobra.Command {
 		sshKey, _ := command.Flags().GetString("ssh-key")
 		merge, _ := command.Flags().GetBool("merge")
 		k3sExtraArgs, _ := command.Flags().GetString("k3s-extra-args")
+		k3sExtraEnvs, _ := command.Flags().GetString("k3s-extra-envs")
 
 		sshKeyPath := expandPath(sshKey)
 		fmt.Printf("ssh -i %s %s@%s\n", sshKeyPath, user, ip.String())
@@ -85,7 +87,7 @@ func MakeInstall() *cobra.Command {
 		defer operator.Close()
 
 		if !skipInstall {
-			installK3scommand := fmt.Sprintf("curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --tls-san %s %s' sh -\n", ip, k3sExtraArgs)
+			installK3scommand := fmt.Sprintf("curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --tls-san %s %s' %s sh -\n", ip, k3sExtraArgs, k3sExtraEnvs)
 			fmt.Printf("ssh: %s\n", installK3scommand)
 			res, err := operator.Execute(installK3scommand)
 


### PR DESCRIPTION
Add support for K3s environment variable 

## Description
This change adds support for the `--k3s-extra-envs` parameter in the command line that set environment variables before running k3s.

## Motivation and Context
K3s 0.9.0 seems to be breaking installation on RasbperryPi ([https://github.com/rancher/k3s/issues/828](https://github.com/rancher/k3s/issues/828))
Since k3sup install the latest stable by default, the ability to pass a specific version was needed. 

This can be also used to test RC's and specific version of k3s.

## How Has This Been Tested?
```./k3sup  install --ip $SERVER_IP --user pi --k3s-extra-envs 'INSTALL_K3S_VERSION=v0.8.1'           <<< 
Public IP: 10.0.0.143                                                                                    
[REDACTED]                                                          
ssh: curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --tls-san 10.0.0.143 ' INSTALL_K3S_VERSION=v0.8.1 sh -                                                                                               
                                                                                                         
[INFO]  Using v0.8.1 as release                                                                          
[INFO]  Downloading hash https://github.com/rancher/k3s/releases/download/v0.8.1/sha256sum-arm.txt       
[INFO]  Downloading binary https://github.com/rancher/k3s/releases/download/v0.8.1/k3s-armhf             
[INFO]  Verifying binary download                                                                        
[INFO]  Installing k3s to /usr/local/bin/k3s                                                             
[INFO]  Creating /usr/local/bin/kubectl symlink to k3s                                                   
[INFO]  Creating /usr/local/bin/crictl symlink to k3s                                                    
[INFO]  Creating /usr/local/bin/ctr symlink to k3s                                                       
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh                                            
[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh                                        
[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env                               
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service                        ```

```./k3sup join --ip $WORKER_IP --server-ip $SERVER_IP --user pi --k3s-extra-envs 'INSTALL_K3S_VERSION=v0.8.1'; done
Server IP: 10.0.0.143
[REDACTED]
ssh: sudo cat /var/lib/rancher/k3s/server/node-token

K10bf3304e453b6f053d6fe65f69fad0e5fc5c393d0baa3483c56a6c5cc187ab32c::node:426e5b7cc05dd0471f2d0644bb3cd40
5
ssh: curl -sfL https://get.k3s.io/ | K3S_URL='https://10.0.0.143:6443' K3S_TOKEN='K10bf3304e453b6f053d6fe
65f69fad0e5fc5c393d0baa3483c56a6c5cc187ab32c::node:426e5b7cc05dd0471f2d0644bb3cd405' INSTALL_K3S_VERSION=
v0.8.1 sh -s -
[INFO]  Using v0.8.1 as release
[INFO]  Downloading hash https://github.com/rancher/k3s/releases/download/v0.8.1/sha256sum-arm.txt
[INFO]  Downloading binary https://github.com/rancher/k3s/releases/download/v0.8.1/k3s-armhf
[INFO]  Verifying binary download
[INFO]  Installing k3s to /usr/local/bin/k3s
[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
[INFO]  Creating /usr/local/bin/crictl symlink to k3s
[INFO]  Creating /usr/local/bin/ctr symlink to k3s
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-agent-uninstall.sh
[INFO]  env: Creating environment file /etc/systemd/system/k3s-agent.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s-agent.service
[INFO]  systemd: Enabling k3s-agent unit
```

```
kubectl get node -o wide                                                                           <<<
NAME       STATUS   ROLES    AGE   VERSION         INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION   CONTAINER-RUNTIME
node1       Ready    worker   23m   v1.14.6-k3s.1   10.0.0.139    <none>        Raspbian GNU/Linux 10 (buster)   4.19.66-v7+      containerd://1.2.7-k3s1
node2       Ready    worker   22m   v1.14.6-k3s.1   10.0.0.140    <none>        Raspbian GNU/Linux 10 (buster)   4.19.66-v7+      containerd://1.2.7-k3s1
node3       Ready    worker   22m   v1.14.6-k3s.1   10.0.0.105    <none>        Raspbian GNU/Linux 10 (buster)   4.19.66-v7l+     containerd://1.2.7-k3s1
node4       Ready    worker   22m   v1.14.6-k3s.1   10.0.0.149    <none>        Raspbian GNU/Linux 10 (buster)   4.19.66-v7l+     containerd://1.2.7-k3s1
node0       Ready    master   25m   v1.14.6-k3s.1   10.0.0.143    <none>        Raspbian GNU/Linux 10 (buster)   4.19.66-v7+      containerd://1.2.7-k3s1

```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
