### PR TITLE
Add version pinning

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	config "github.com/alexellis/k3sup/pkg/config"
 	kssh "github.com/alexellis/k3sup/pkg/ssh"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -40,6 +41,7 @@ func MakeInstall() *cobra.Command {
 	command.Flags().String("local-path", "kubeconfig", "Local path to save the kubeconfig file")
 	command.Flags().String("k3s-extra-args", "", "Optional extra arguments to pass to k3s installer, wrapped in quotes (e.g. --k3s-extra-args '--no-deploy servicelb')")
 	command.Flags().Bool("merge", false, "Merge the config with existing kubeconfig if it already exists.\nProvide the --local-path flag with --merge if a kubeconfig already exists in some other directory")
+	command.Flags().String("k3s-version", config.K3sVersion, "Optional version to install, pinned at a default")
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 
@@ -56,6 +58,8 @@ func MakeInstall() *cobra.Command {
 		sshKey, _ := command.Flags().GetString("ssh-key")
 		merge, _ := command.Flags().GetBool("merge")
 		k3sExtraArgs, _ := command.Flags().GetString("k3s-extra-args")
+
+		k3sVersion, _ := command.Flags().GetString("k3s-version")
 
 		sshKeyPath := expandPath(sshKey)
 		fmt.Printf("ssh -i %s %s@%s\n", sshKeyPath, user, ip.String())
@@ -85,7 +89,8 @@ func MakeInstall() *cobra.Command {
 		defer operator.Close()
 
 		if !skipInstall {
-			installK3scommand := fmt.Sprintf("curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --tls-san %s %s' sh -\n", ip, k3sExtraArgs)
+			installK3scommand := fmt.Sprintf("curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --tls-san %s %s' INSTALL_K3S_VERSION='%s' sh -\n", ip, strings.TrimSpace(k3sExtraArgs), k3sVersion)
+
 			fmt.Printf("ssh: %s\n", installK3scommand)
 			res, err := operator.Execute(installK3scommand)
 

--- a/pkg/cmd/join.go
+++ b/pkg/cmd/join.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strings"
 
+	config "github.com/alexellis/k3sup/pkg/config"
 	kssh "github.com/alexellis/k3sup/pkg/ssh"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -29,6 +30,7 @@ func MakeJoin() *cobra.Command {
 	command.Flags().Int("ssh-port", 22, "The port on which to connect for ssh")
 	command.Flags().Bool("skip-install", false, "Skip the k3s installer")
 	command.Flags().String("k3s-extra-args", "", "Optional extra arguments to pass to k3s installer, wrapped in quotes (e.g. --k3s-extra-args '--node-taint key=value:NoExecute')")
+	command.Flags().String("k3s-version", config.K3sVersion, "Optional version to install, pinned at a default")
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 
@@ -44,6 +46,8 @@ func MakeJoin() *cobra.Command {
 		port, _ := command.Flags().GetInt("ssh-port")
 
 		k3sExtraArgs, _ := command.Flags().GetString("k3s-extra-args")
+
+		k3sVersion, _ := command.Flags().GetString("k3s-version")
 
 		sshKeyPath := expandPath(sshKey)
 		fmt.Printf("ssh -i %s %s@%s\n", sshKeyPath, user, serverIP.String())
@@ -87,7 +91,7 @@ func MakeJoin() *cobra.Command {
 
 		joinToken := string(res.StdOut)
 
-		setupAgent(serverIP, ip, port, user, sshKeyPath, joinToken, k3sExtraArgs)
+		setupAgent(serverIP, ip, port, user, sshKeyPath, joinToken, k3sExtraArgs, k3sVersion)
 
 		return nil
 	}
@@ -113,7 +117,7 @@ func MakeJoin() *cobra.Command {
 	return command
 }
 
-func setupAgent(serverIP, ip net.IP, port int, user, sshKeyPath, joinToken string, k3sExtraArgs string) error {
+func setupAgent(serverIP, ip net.IP, port int, user, sshKeyPath, joinToken, k3sExtraArgs, k3sVersion string) error {
 
 	authMethod, closeSSHAgent, err := loadPublickey(sshKeyPath)
 	if err != nil {
@@ -139,7 +143,7 @@ func setupAgent(serverIP, ip net.IP, port int, user, sshKeyPath, joinToken strin
 
 	defer operator.Close()
 
-	getTokenCommand := fmt.Sprintf("curl -sfL https://get.k3s.io/ | K3S_URL='https://%s:6443' K3S_TOKEN='%s' sh -s - %s", serverIP.String(), strings.TrimSpace(joinToken), k3sExtraArgs)
+	getTokenCommand := fmt.Sprintf("curl -sfL https://get.k3s.io/ | K3S_URL='https://%s:6443' K3S_TOKEN='%s' INSTALL_K3S_VERSION='%s' sh -s - %s", serverIP.String(), strings.TrimSpace(joinToken), k3sVersion, k3sExtraArgs)
 	fmt.Printf("ssh: %s\n", getTokenCommand)
 
 	res, err := operator.Execute(getTokenCommand)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,4 @@
+package config
+
+// K3sVersion default version
+const K3sVersion = "v0.8.1"


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add version pinning

## Motivation and Context

This commit adds the --k3s-version flag to install/join and fixes
an issue reported by @GnaphronG in PR #35. Rather than adding a
user-facing "extra-envs" command, this has been wrapped up in a
flag for a more concise UX.

The default has also been pinned to v0.8.0 due to his report of
v0.9.0 not working on Raspberry Pi, which is a primary use-case
for k3sup.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by creating cluster with v0.8.0 with 2x RPi4.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
