### PR TITLE
Add context flag to server command

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Other options for `install`:
 * `--skip-install` - if you already have k3s installed, you can just run this command to get the `kubeconfig`
 * `--ssh-key` - specify a specific path for the SSH key for remote login
 * `--local-path` - default is `./kubeconfig` - set the path into which you want to save your VM's `kubeconfig`
+* `--context` - default is `default` - set the name of the kubeconfig context.
 * `--ssh-port` - default is `22`, but you can specify an alternative port i.e. `2222`
 * `--k3s-extra-args` - Optional extra arguments to pass to k3s installer, wrapped in quotes, i.e. `--k3s-extra-args '--docker --no-deploy servicelb'`
 

--- a/pkg/cmd/install_test.go
+++ b/pkg/cmd/install_test.go
@@ -40,7 +40,7 @@ func Test_loadPublickeyEncrypted(t *testing.T) {
 	}
 
 	tmpfile.Close()
-	_, err = loadPublickey(tmpfile.Name())
+	_, _, err = loadPublickey(tmpfile.Name())
 	if err.Error() != expected {
 		t.Errorf("Unexpected error, got: %q, want: %q.", err.Error(), expected)
 	}


### PR DESCRIPTION
## Description
This flag can be used to define what name to use as context in the
generated kubeconfig file. The default is default.

Closes #39 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
I've tested it running the command with the `--context` flag and a combinations of `--local-path` and `--merge` flags

This is the default behaviour
```
./k3sup install --ip $SERVER_IP --user ubuntu --ssh-key ~/.ssh/id_ed25519 --skip-install

KUBECONFIG="./kubeconfig" kubectl config view
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: DATA+OMITTED
    server: https://192.168.86.59:6443
  name: default
contexts:
- context:
    cluster: default
    user: default
  name: default
current-context: default
kind: Config
preferences: {}
users:
- name: default
  user:
    password: 5ceb3a3e93621d265fd147929f3ace84
    username: admin
```

Passing the `--context` flag
```
./k3sup install --ip $SERVER_IP --user ubuntu --ssh-key ~/.ssh/id_ed25519 --skip-install --context homelab

KUBECONFIG="./kubeconfig" kubectl config view
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: DATA+OMITTED
    server: https://192.168.86.59:6443
  name: homelab
contexts:
- context:
    cluster: homelab
    user: homelab
  name: homelab
current-context: homelab
kind: Config
preferences: {}
users:
- name: homelab
  user:
    password: 5ceb3a3e93621d265fd147929f3ace84
    username: admin
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
