### PR TITLE
Replace 127.0.0.1 with Public IP address while generating kube config

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -114,7 +114,7 @@ func MakeInstall() *cobra.Command {
 
 		absPath, _ := filepath.Abs(localKubeconfig)
 
-		kubeconfig := []byte(strings.Replace(string(res.StdOut), "localhost", ip.String(), -1))
+		kubeconfig := []byte(strings.NewReplacer("localhost", ip.String(), "127.0.0.1", ip.String()).Replace(string(res.StdOut)))
 
 		if merge {
 			// Create a merged kubeconfig


### PR DESCRIPTION
Replaces 127.0.0.1 in addition to localhost
in KUBECONFIG to support k3s 0.9.0

Signed-off-by: Greg Osuri <me@gregosuri.com>

## Description
Replaces 127.0.0.1 in addition to localhost while generating kube config

## Motivation and Context
Fixes #43 
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
I have tested the changes with k3s v0.8.2 and v0.9.0 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.