### PR TITLE
Add cert-manager and fix the ASCII logo

### DIFF
--- a/pkg/cmd/apps.go
+++ b/pkg/cmd/apps.go
@@ -26,6 +26,7 @@ func MakeApps() *cobra.Command {
 
 	install.Flags().String("kubeconfig", "kubeconfig", "Local path for your kubeconfig file")
 
+	certmanager := makeInstallCertManager()
 	openfaas := makeInstallOpenFaaS()
 	metricsserver := makeInstallMetricsServer()
 
@@ -40,6 +41,7 @@ func MakeApps() *cobra.Command {
 	}
 
 	command.AddCommand(install)
+	install.AddCommand(certmanager)
 	install.AddCommand(openfaas)
 	install.AddCommand(metricsserver)
 

--- a/pkg/cmd/certmanager_app.go
+++ b/pkg/cmd/certmanager_app.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+
+	"github.com/alexellis/k3sup/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+func makeInstallCertManager() *cobra.Command {
+	var certManager = &cobra.Command{
+		Use:          "cert-manager",
+		Short:        "Install cert-manager",
+		Long:         "Install Cert-Manager",
+		Example:      "k3sup install cert-manager --namespace cert-manager",
+		SilenceUsage: true,
+	}
+
+	certManager.Flags().StringP("namespace", "n", "cert-manager", "The namespace to install cert-manager")
+
+	certManager.RunE = func(command *cobra.Command, args []string) error {
+		kubeConfigPath := getDefaultKubeconfig()
+
+		if command.Flags().Changed("kubeconfig") {
+			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
+		}
+
+		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
+
+		namespace, _ := command.Flags().GetString("namespace")
+
+		if namespace != "cert-manager" {
+			return fmt.Errorf(`To override the "cert-manager" namespace, install cert-manager via helm manually`)
+		}
+
+		arch := getArchitecture()
+		fmt.Printf("Node architecture: %s\n", arch)
+
+		userPath, err := config.InitUserDir()
+		if err != nil {
+			return err
+		}
+
+		clientArch, clientOS := getClientArch()
+
+		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
+
+		log.Printf("User dir established as: %s\n", userPath)
+
+		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
+
+		err = tryDownloadHelm(userPath, clientArch, clientOS)
+		if err != nil {
+			return err
+		}
+
+		err = addHelmRepo("jetstack", "https://charts.jetstack.io")
+		if err != nil {
+			return err
+		}
+
+		err = updateHelmRepos()
+		if err != nil {
+			return err
+		}
+
+		err = kubectl("create", "namespace", namespace)
+		if err != nil {
+			return err
+		}
+
+		chartPath := path.Join(os.TempDir(), "charts")
+
+		err = fetchChart(chartPath, "jetstack/cert-manager")
+		if err != nil {
+			return err
+		}
+
+		outputPath := path.Join(chartPath, "cert-manager/rendered")
+
+		err = templateChart(chartPath, "cert-manager", namespace, outputPath, "values.yaml", nil)
+		if err != nil {
+			return err
+		}
+
+		err = kubectl("apply", "-f", "--validate", "false", "https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/deploy/manifests/00-crds.yaml")
+		if err != nil {
+			return err
+		}
+
+		err = kubectl("apply", "-n", namespace, "-R", "-f", outputPath)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(`=======================================================================
+= cert-manager has been installed.                                    =
+=======================================================================
+
+# Get started with cert-manager here:
+# https://docs.cert-manager.io/en/latest/tutorials/acme/http-validation.html
+		
+Thank you for using k3sup!`)
+
+		return nil
+	}
+
+	return certManager
+}

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -36,7 +36,7 @@ func MakeVersion() *cobra.Command {
 	return command
 }
 
-const k3supFigletStr = `_    _____                 
+const k3supFigletStr = ` _    _____                 
 | | _|___ / ___ _   _ _ __  
 | |/ / |_ \/ __| | | | '_ \ 
 |   < ___) \__ \ |_| | |_) |


### PR DESCRIPTION
Need some help as cert-manager pods are not showing up in the cert-manager namespace

Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
