### PR TITLE
Switch to writable test in get.sh

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -4,6 +4,7 @@
 export OWNER=alexellis
 export REPO=k3sup
 export SUCCESS_CMD="$REPO version"
+export BINLOCATION="/usr/local/bin"
 
 version=$(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep Location | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
 
@@ -13,7 +14,7 @@ if [ ! $version ]; then
     echo "1. Open your web browser and go to https://github.com/$OWNER/$REPO/releases"
     echo "2. Download the latest release for your platform. Call it '$REPO'."
     echo "3. chmod +x ./$REPO"
-    echo "4. mv ./$REPO /usr/local/bin"
+    echo "4. mv ./$REPO $BINLOCATION"
     exit 1
 fi
 
@@ -83,26 +84,27 @@ getPackage() {
 
     echo "Download complete."
 
-        if [ "$userid" != "0" ]; then
+        if [ ! -w "$BINLOCATION" ]; then
 
             echo
-            echo "========================================================="
-            echo "==    As the script was run as a non-root user the     =="
-            echo "==    following commands may need to be run manually   =="
-            echo "========================================================="
+            echo "============================================================"
+            echo "==   The script was run as a user who is unable to write  =="
+            echo "==   to $BINLOCATION. To complete the installation the  =="
+            echo "==   following commands may need to be run manually.      =="
+            echo "============================================================"
             echo
-            echo "  sudo cp $REPO /usr/local/bin/$REPO"
+            echo "  sudo cp $REPO $BINLOCATION/$REPO"
             echo
 
         else
 
             echo
-            echo "Running as root - Attempting to move $REPO to /usr/local/bin"
+            echo "Running with sufficient permissions to attempt to move $REPO to $BINLOCATION"
 
-            mv $targetFile /usr/local/bin/$REPO
+            mv $targetFile $BINLOCATION/$REPO
 
             if [ "$?" = "0" ]; then
-                echo "New version of $REPO installed to /usr/local/bin"
+                echo "New version of $REPO installed to $BINLOCATION"
             fi
 
             if [ -e $targetFile ]; then


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description

This change moves the if statement away from testing for the root user and instead checks for writability for the current location.

## Motivation and Context
The evaluation prior to moving the binary in get.sh was checking for the root user.  However, if the current user has sufficient privileges to write to the target location then there would be no reason not to attempt the move as the current user.
- [x] I have raised an issue to propose this change (Fixes #58)


## How Has This Been Tested?
### As a user with write access:
```sh
$ ls -ld /usr/local/bin
drwxrwxr-x  326 rgee0  staff  10432 22 Oct 21:00 /usr/local/bin
$ id -F
RGee0
$ ./get.sh

You already have the k3sup cli!
Overwriting in 1 seconds.. Press Control+C to cancel.

Downloading package https://github.com/alexellis/k3sup/releases/download/0.5.0/k3sup-darwin as /Users/rgee0/go/src/github.com/alexellis/k3sup/k3sup
Download complete.

Running with sufficient permissions to attempt to move k3sup to /usr/local/bin
New version of k3sup installed to /usr/local/bin
 _    _____                 
| | _|___ / ___ _   _ _ __  
| |/ / |_ \/ __| | | | '_ \ 
|   < ___) \__ \ |_| | |_) |
|_|\_\____/|___/\__,_| .__/ 
                     |_|    
Version: 0.5.0
Git Commit: 9acc7a6932288270d19d02004038488072c8882b
```

### Using sudo:
```sh
$ sudo ./get.sh

You already have the k3sup cli!
Overwriting in 1 seconds.. Press Control+C to cancel.

Downloading package https://github.com/alexellis/k3sup/releases/download/0.5.0/k3sup-darwin as /tmp/k3sup
Download complete.

Running with sufficient permissions to attempt to move k3sup to /usr/local/bin
New version of k3sup installed to /usr/local/bin
 _    _____                 
| | _|___ / ___ _   _ _ __  
| |/ / |_ \/ __| | | | '_ \ 
|   < ___) \__ \ |_| | |_) |
|_|\_\____/|___/\__,_| .__/ 
                     |_|    
Version: 0.5.0
Git Commit: 9acc7a6932288270d19d02004038488072c8882b
$ 
```

### Unprivileged user
```sh 
$ ls -ld /usr/local/bin
drwxrwxr-x  326 rgee0  staff  10432 22 Oct 21:03 /usr/local/bin
$ id -F
Guest User
$ ./get.sh

You already have the k3sup cli!
Overwriting in 1 seconds.. Press Control+C to cancel.

Downloading package https://github.com/alexellis/k3sup/releases/download/0.5.0/k3sup-darwin as /tmp/k3sup
Download complete.

============================================================
==   The script was run as a user who is unable to write  ==
==   to /usr/local/bin. To complete the installation the  ==
==   following commands may need to be run manually.      ==
============================================================

  sudo cp k3sup /usr/local/bin/k3sup

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
