### PR TITLE
Add additional check for binary permissions to get.sh

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -101,6 +101,19 @@ getPackage() {
             echo
             echo "Running with sufficient permissions to attempt to move $REPO to $BINLOCATION"
 
+            if [ ! -w "$BINLOCATION/$REPO" ] && [ -f "$BINLOCATION/$REPO" ]; then
+
+            echo
+            echo "================================================================"
+            echo "==  $BINLOCATION/$REPO already exists and is not writeable  =="
+            echo "==  by the current user.  Please adjust the binary ownership  =="
+            echo "==  or run with sudo:  curl -SLs get.k3sup.dev | sudo sh      ==" 
+            echo "================================================================"
+            echo
+            exit 1
+
+            fi
+
             mv $targetFile $BINLOCATION/$REPO
 
             if [ "$?" = "0" ]; then


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
This change adds an additional check to assess whether the binary already exists and whether it is writable by the current user.  It exits with an informative message in the event that the binary is not writeable.

## Motivation and Context
There was a scenario whereby if the k3sup binary already existed on a system having been downloaded through a `| sudo sh` its ownership would be root.  This would cause overwrite messages when run as the current user through the recent change to test for directory writeability rather than root user.
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Related to #60 and #58

## How Has This Been Tested?

### As a guest user
```sh
$ cd /tmp
$ /Users/rgee0/go/src/github.com/alexellis/k3sup/get.sh

You already have the k3sup cli!
Overwriting in 1 seconds.. Press Control+C to cancel.

Downloading package https://github.com/alexellis/k3sup/releases/download/0.5.0/k3sup-darwin as /tmp/k3sup
Download complete.

============================================================
==   The script was run as a user who is unable to write  ==
==   to /usr/local/bin. To complete the installation the  ==
==   following commands may need to be run manually.      ==
============================================================

  sudo cp k3sup /usr/local/bin/k3sup
```
### As a user who can write to /usr/local/bin but doesnt own the binary
```sh
$ ls -ld /usr/local/bin
drwxrwxr-x  326 rgee0  staff  10432 22 Oct 21:26 /usr/local/bin
$ ls -la /usr/local/bin/k3sup
-rwxr-xr-x  1 root  wheel  8310488 22 Oct 21:26 /usr/local/bin/k3sup
$ ./get.sh

You already have the k3sup cli!
Overwriting in 1 seconds.. Press Control+C to cancel.

Downloading package https://github.com/alexellis/k3sup/releases/download/0.5.0/k3sup-darwin as /Users/rgee0/go/src/github.com/alexellis/k3sup/k3sup
Download complete.

Running with sufficient permissions to attempt to move k3sup to /usr/local/bin

================================================================
==  /usr/local/bin/k3sup already exists and is not writeable  ==
==  by the current user.  Please adjust the binary ownership  ==
==  or run with sudo:  curl -SLs get.k3sup.dev | sudo sh      ==
================================================================
```
### Using sudo
```sh
$ sudo ./get.sh

You already have the k3sup cli!
Overwriting in 1 seconds.. Press Control+C to cancel.

Downloading package https://github.com/alexellis/k3sup/releases/download/0.5.0/k3sup-darwin as /tmp/k3sup
Download complete.

Running with sufficient permissions to attempt to move k3sup to /usr/local/bin
New version of k3sup installed to /usr/local/bin
 _    _____                 
| | _|___ / ___ _   _ _ __  
| |/ / |_ \/ __| | | | '_ \ 
|   < ___) \__ \ |_| | |_) |
|_|\_\____/|___/\__,_| .__/ 
                     |_|    
Version: 0.5.0
Git Commit: 9acc7a6932288270d19d02004038488072c8882b
```

### After adjusting the binary ownership
```sh
$ ls -ld /usr/local/bin
drwxrwxr-x  326 rgee0  staff  10432 22 Oct 21:57 /usr/local/bin
$ ls -la /usr/local/bin/k3sup
-rwxr-xr-x  1 root  wheel  8310488 22 Oct 21:57 /usr/local/bin/k3sup
$ sudo chown rgee0:staff /usr/local/bin/k3sup
$ ls -la /usr/local/bin/k3sup
-rwxr-xr-x  1 rgee0  staff  8310488 22 Oct 21:57 /usr/local/bin/k3sup
$ ./get.sh

You already have the k3sup cli!
Overwriting in 1 seconds.. Press Control+C to cancel.

Downloading package https://github.com/alexellis/k3sup/releases/download/0.5.0/k3sup-darwin as /Users/rgee0/go/src/github.com/alexellis/k3sup/k3sup
Download complete.

Running with sufficient permissions to attempt to move k3sup to /usr/local/bin
New version of k3sup installed to /usr/local/bin
 _    _____                 
| | _|___ / ___ _   _ _ __  
| |/ / |_ \/ __| | | | '_ \ 
|   < ___) \__ \ |_| | |_) |
|_|\_\____/|___/\__,_| .__/ 
                     |_|    
Version: 0.5.0
Git Commit: 9acc7a6932288270d19d02004038488072c8882b
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
