### PR TITLE
Remove notice about canceling download of script

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -20,17 +20,6 @@ fi
 
 hasCli() {
 
-    has=$(which $REPO)
-
-    if [ "$?" = "0" ]; then
-        echo
-        echo "You already have the $REPO cli!"
-        export n=1
-        echo "Overwriting in $n seconds.. Press Control+C to cancel."
-        echo
-        sleep $n
-    fi
-
     hasCurl=$(which curl)
     if [ "$?" = "1" ]; then
         echo "You need curl to use this script."


### PR DESCRIPTION
There was a notice to cancel download of the script if you had
it installed that was set to say you had 1 second to cancel.
We always install the latest version so if a user wants to
reinstall then its fine. The check has been removed.

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
running script locally still installs when its there, now it doesn't give 1 second delay.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
