### PR TITLE
Fix passing parameters to metric-server.

### DIFF
--- a/pkg/cmd/metricsserver_app.go
+++ b/pkg/cmd/metricsserver_app.go
@@ -66,7 +66,7 @@ func makeInstallMetricsServer() *cobra.Command {
 		}
 
 		overrides := map[string]string{}
-		overrides["args"] = `{--kubelet-insecure-tls,--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname}`
+		overrides["args"] = `{--kubelet-insecure-tls,--kubelet-preferred-address-types=InternalIP\,ExternalIP\,Hostname}`
 		fmt.Println("Chart path: ", chartPath)
 		outputPath := path.Join(chartPath, "metrics-server/rendered")
 


### PR DESCRIPTION
Commas in the *values* of parameters passed to helm via --set must be
backslash-escaped. Otherwise, values are passed as separate parameters.


