### PR TITLE
Fix installation of metrics-server app

### DIFF
--- a/pkg/cmd/metricsserver_app.go
+++ b/pkg/cmd/metricsserver_app.go
@@ -16,11 +16,11 @@ func makeInstallMetricsServer() *cobra.Command {
 		Use:          "metrics-server",
 		Short:        "Install metrics-server",
 		Long:         `Install metrics-server`,
-		Example:      `  k3sup app install metrics-server --namespace default`,
+		Example:      `  k3sup app install metrics-server --namespace kube-system`,
 		SilenceUsage: true,
 	}
 
-	metricsServer.Flags().StringP("namespace", "n", "default", "The namespace used for installation")
+	metricsServer.Flags().StringP("namespace", "n", "kube-system", "The namespace used for installation")
 
 	metricsServer.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
@@ -37,8 +37,8 @@ func makeInstallMetricsServer() *cobra.Command {
 		}
 		namespace, _ := command.Flags().GetString("namespace")
 
-		if namespace != "default" {
-			return fmt.Errorf(`to override the "default", install via tiller`)
+		if namespace != "kube-system" {
+			return fmt.Errorf(`to override the "kube-system", install via tiller`)
 		}
 
 		clientArch, clientOS := getClientArch()
@@ -70,11 +70,9 @@ func makeInstallMetricsServer() *cobra.Command {
 		fmt.Println("Chart path: ", chartPath)
 		outputPath := path.Join(chartPath, "metrics-server/rendered")
 
-		// ns:="kube-system"
-		ns := "default"
 		err = templateChart(chartPath,
 			"metrics-server",
-			ns,
+			namespace,
 			outputPath,
 			"values.yaml",
 			overrides)
@@ -83,7 +81,7 @@ func makeInstallMetricsServer() *cobra.Command {
 			return err
 		}
 
-		err = kubectl("apply", "-R", "-f", outputPath)
+		err = kubectl("-n", namespace, "apply", "-R", "-f", outputPath)
 
 		if err != nil {
 			return err


### PR DESCRIPTION
Always install in "kube-system" namespace by using 'kubectl -n'

Signed-off-by: Jetchko Jekov <jetchko.jekov@gmail.com>

## Description
Forcing installation in "kube-system" namespace solves the currently broken installation
in the case when the namespace set by the context in which k3sup is running is different from 
the namespace provided with -n parameter during the installation of metrics-server app.

## Motivation and Context
Currently, installation is broken in the case described above.
It fixes #77 
- [ X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Successful install of working metrics-server app no matter what is current namespace set 
by the context.

## Types of changes
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
