### PR TITLE
Make get.sh generic for cross repo sharing

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
-# This script was adapted from https://github.com/openfaas/cli.openfaas.com/blob/master/get.sh
 
+# Copyright OpenFaaS Author(s) 2019
+#########################
+# Repo specific content #
+#########################
+
+export VERIFY_CHECKSUM=0
+export ALIAS=""
 export OWNER=alexellis
 export REPO=k3sup
 export SUCCESS_CMD="$REPO version"
 export BINLOCATION="/usr/local/bin"
 
-version=$(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep Location | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
+###############################
+# Content common across repos #
+###############################
 
+version=$(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep Location | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
 if [ ! $version ]; then
     echo "Failed while attempting to install $REPO. Please manually install:"
     echo ""
@@ -15,6 +24,9 @@ if [ ! $version ]; then
     echo "2. Download the latest release for your platform. Call it '$REPO'."
     echo "3. chmod +x ./$REPO"
     echo "4. mv ./$REPO $BINLOCATION"
+    if [ -n "$ALIAS_NAME" ]; then
+        echo "5. ln -sf $BINLOCATION/$REPO /usr/local/bin/$ALIAS_NAME"
+    fi
     exit 1
 fi
 
@@ -27,12 +39,33 @@ hasCli() {
     fi
 }
 
+checkHash(){
+
+    sha_cmd="sha256sum"
+
+    if [ ! -x "$(command -v $sha_cmd)" ]; then
+    sha_cmd="shasum -a 256"
+    fi
+
+    if [ -x "$(command -v $sha_cmd)" ]; then
+
+    targetFileDir=${targetFile%/*}
+
+    (cd $targetFileDir && curl -sSL $url.sha256|$sha_cmd -c >/dev/null)
+   
+        if [ "$?" != "0" ]; then
+            rm $targetFile
+            echo "Binary checksum didn't match. Exiting"
+            exit 1
+        fi   
+    fi
+}
+
 getPackage() {
     uname=$(uname)
     userid=$(id -u)
 
     suffix=""
-
     case $uname in
     "Darwin")
     suffix="-darwin"
@@ -46,7 +79,6 @@ getPackage() {
     "Linux")
         arch=$(uname -m)
         echo $arch
-
         case $arch in
         "aarch64")
         suffix="-arm64"
@@ -60,10 +92,10 @@ getPackage() {
     ;;
     esac
 
-    targetFile="/tmp/$REPO"
-
+    targetFile="/tmp/$REPO$suffix"
+    
     if [ "$userid" != "0" ]; then
-        targetFile="$(pwd)/$REPO"
+        targetFile="$(pwd)/$REPO$suffix"
     fi
 
     if [ -e $targetFile ]; then
@@ -73,15 +105,19 @@ getPackage() {
     url=https://github.com/$OWNER/$REPO/releases/download/$version/$REPO$suffix
     echo "Downloading package $url as $targetFile"
 
-    curl -sSLf $url --output $targetFile
+    curl -sSL $url --output $targetFile
 
     if [ "$?" = "0" ]; then
+
+        if [ "$VERIFY_CHECKSUM" = "1" ]; then
+            checkHash
+        fi
 
     chmod +x $targetFile
 
     echo "Download complete."
-
-        if [ ! -w "$BINLOCATION" ]; then
+       
+    if [ ! -w "$BINLOCATION" ]; then
 
             echo
             echo "============================================================"
@@ -90,7 +126,12 @@ getPackage() {
             echo "  following commands may need to be run manually."
             echo "============================================================"
             echo
-            echo "  sudo cp $REPO $BINLOCATION/$REPO"
+            echo "  sudo cp $REPO$suffix $BINLOCATION/$REPO"
+            
+            if [ -n "$ALIAS_NAME" ]; then
+                echo "  sudo ln -sf $BINLOCATION/$REPO $BINLOCATION/$ALIAS_NAME"
+            fi
+            
             echo
 
         else
@@ -112,7 +153,7 @@ getPackage() {
             fi
 
             mv $targetFile $BINLOCATION/$REPO
-
+        
             if [ "$?" = "0" ]; then
                 echo "New version of $REPO installed to $BINLOCATION"
             fi
@@ -121,7 +162,14 @@ getPackage() {
                 rm $targetFile
             fi
 
-           ${SUCCESS_CMD}
+            if [ -n "$ALIAS_NAME" ]; then
+                if [ ! -L $BINLOCATION/$ALIAS_NAME ]; then
+                    ln -s $BINLOCATION/$REPO $BINLOCATION/$ALIAS_NAME
+                    echo "Creating alias '$ALIAS_NAME' for '$REPO'."
+                fi
+            fi
+
+            ${SUCCESS_CMD}
         fi
     fi
 }


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
Currently the get.sh scripts across a number of repos are roughly based off the faas-cli file with bespoke changes made depending upon the needs of the respective projects.

This change make the faas-cli script generic enough so that the common content can be used across all the repos without any changes.  The only changes required to tailor the file's operation to the respective repo are to be made in the repo specific content section.

Also adds a check for a git bash signature to enable downloading of the .exe variant when running on git bash on Windows.

**NOTE:** As the script has been brought across from faas-cli the -f has been dropped from the curl command. If required this can be reapplied and also put into the faas-cli.

## Motivation and Context
Lower maintenance cost across multiple repos

- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
### Clean install
```sh
$ ls -la /usr/local/bin/ | grep k3sup
$ ./get.sh
Downloading package https://github.com/alexellis/k3sup/releases/download/0.5.4/k3sup-darwin as /Users/rgee0/go/src/github.com/alexellis/k3sup/k3sup-darwin
Download complete.

Running with sufficient permissions to attempt to move k3sup to /usr/local/bin
New version of k3sup installed to /usr/local/bin
 _    _____                 
| | _|___ / ___ _   _ _ __  
| |/ / |_ \/ __| | | | '_ \ 
|   < ___) \__ \ |_| | |_) |
|_|\_\____/|___/\__,_| .__/ 
                     |_|    
Version: 0.5.4
Git Commit: f2896dbe95b1f2e692a5a2b75c9102e0636814cb
```

### Overwrite install
```sh
$ ls -la /usr/local/bin/ | grep k3sup
-rwxr-xr-x    1 rgee0       staff   9003424  1 Nov 19:23 k3sup
$ ./get.sh
Downloading package https://github.com/alexellis/k3sup/releases/download/0.5.4/k3sup-darwin as /Users/rgee0/go/src/github.com/alexellis/k3sup/k3sup-darwin
Download complete.

Running with sufficient permissions to attempt to move k3sup to /usr/local/bin
New version of k3sup installed to /usr/local/bin
 _    _____                 
| | _|___ / ___ _   _ _ __  
| |/ / |_ \/ __| | | | '_ \ 
|   < ___) \__ \ |_| | |_) |
|_|\_\____/|___/\__,_| .__/ 
                     |_|    
Version: 0.5.4
Git Commit: f2896dbe95b1f2e692a5a2b75c9102e0636814cb
$ ls -la /usr/local/bin/ | grep k3sup
-rwxr-xr-x    1 rgee0       staff   9003424  1 Nov 19:26 k3sup
```
### Overwrite install using sudo
```sh
$ ls -la /usr/local/bin/ | grep k3sup
-rwxr-xr-x    1 rgee0       staff   9003424  1 Nov 19:26 k3sup
$ sudo ./get.sh
Downloading package https://github.com/alexellis/k3sup/releases/download/0.5.4/k3sup-darwin as /tmp/k3sup-darwin
Download complete.

Running with sufficient permissions to attempt to move k3sup to /usr/local/bin
New version of k3sup installed to /usr/local/bin
 _    _____                 
| | _|___ / ___ _   _ _ __  
| |/ / |_ \/ __| | | | '_ \ 
|   < ___) \__ \ |_| | |_) |
|_|\_\____/|___/\__,_| .__/ 
                     |_|    
Version: 0.5.4
Git Commit: f2896dbe95b1f2e692a5a2b75c9102e0636814cb
$ ls -la /usr/local/bin/ | grep k3sup
-rwxr-xr-x    1 root        wheel   9003424  1 Nov 19:28 k3sup
```
### Non-sudo install after sudo install
```sh
$ ls -la /usr/local/bin/ | grep k3sup
-rwxr-xr-x    1 root        wheel   9003424  1 Nov 19:28 k3sup
$ ./get.sh
Downloading package https://github.com/alexellis/k3sup/releases/download/0.5.4/k3sup-darwin as /Users/rgee0/go/src/github.com/alexellis/k3sup/k3sup-darwin
Download complete.

Running with sufficient permissions to attempt to move k3sup to /usr/local/bin

================================================================
  /usr/local/bin/k3sup already exists and is not writeable
  by the current user.  Please adjust the binary ownership
  or run sh/bash with sudo.
================================================================

$ ls -la /usr/local/bin/ | grep k3sup
-rwxr-xr-x    1 root        wheel   9003424  1 Nov 19:28 k3sup
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
