### PR TITLE
Update helm version to v2.15.2

### DIFF
--- a/pkg/cmd/openfaas_app.go
+++ b/pkg/cmd/openfaas_app.go
@@ -2,16 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
-	"net/http"
-	"net/url"
 	"os"
 	"path"
 	"strconv"
 	"strings"
-
-	execute "github.com/alexellis/go-execute/pkg/v1"
 
 	"github.com/sethvargo/go-password/password"
 
@@ -178,60 +173,6 @@ Thank you for using k3sup!`)
 	}
 
 	return openfaas
-}
-
-// getClientArch returns a pair of arch and os
-func getClientArch() (string, string) {
-	task := execute.ExecTask{Command: "uname", Args: []string{"-m"}}
-	res, err := task.Execute()
-	if err != nil {
-		log.Println(err)
-	}
-
-	arch := strings.TrimSpace(res.Stdout)
-
-	taskOS := execute.ExecTask{Command: "uname", Args: []string{"-s"}}
-	resOS, errOS := taskOS.Execute()
-	if errOS != nil {
-		log.Println(errOS)
-	}
-
-	os := strings.TrimSpace(resOS.Stdout)
-
-	return arch, os
-}
-
-func getHelmURL(arch, os, version string) string {
-	archSuffix := "amd64"
-	osSuffix := strings.ToLower(os)
-
-	if strings.HasPrefix(arch, "armv7") {
-		archSuffix = "arm"
-	} else if strings.HasPrefix(arch, "aarch64") {
-		archSuffix = "arm64"
-	}
-
-	return fmt.Sprintf("https://get.helm.sh/helm-%s-%s-%s.tar.gz", version, osSuffix, archSuffix)
-}
-
-func downloadHelm(userPath, clientArch, clientOS string) error {
-	helmURL := getHelmURL(clientArch, clientOS, "v2.14.3")
-	fmt.Println(helmURL)
-	parsedURL, _ := url.Parse(helmURL)
-
-	res, err := http.DefaultClient.Get(parsedURL.String())
-	if err != nil {
-		return err
-	}
-
-	defer res.Body.Close()
-	r := ioutil.NopCloser(res.Body)
-	untarErr := Untar(r, path.Join(userPath, ".bin"))
-	if untarErr != nil {
-		return untarErr
-	}
-
-	return nil
 }
 
 func getValuesSuffix(arch string) string {


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Update helm version to v2.15.2

## Motivation and Context

Version v2.15.2 includes some incremental fixes.

## How Has This Been Tested?

Removed helm, saw it download the new version

```
rm -rf ~/.k3sup

./k3sup app install openfaas

Client: "x86_64", "Darwin"
2019/11/03 18:32:07 User dir established as: /Users/alex/.k3sup/
https://get.helm.sh/helm-v2.15.2-darwin-amd64.tar.gz
/Users/alex/.k3sup/.bin/darwin-amd64 darwin-amd64/
/Users/alex/.k3sup/.bin/tiller darwin-amd64/tiller
/Users/alex/.k3sup/.bin/helm darwin-amd64/helm
/Users/alex/.k3sup/.bin/README.md darwin-amd64/README.md
/Users/alex/.k3sup/.bin/LICENSE darwin-amd64/LICENSE
2019/11/03 18:32:10 extracted tarball into /Users/alex/.k3sup/.bin: 4 files, 0 dirs (1.903473049s)
exec:  /Users/alex/.k3sup/.bin/helm init --client-only
res: Creating /Users/alex/.k3sup/.helm/repository 
Creating /Users/alex/.k3sup/.helm/repository/cache 
Creating /Users/alex/.k3sup/.helm/repository/local 
Creating /Users/alex/.k3sup/.helm/plugins 
Creating /Users/alex/.k3sup/.helm/starters 
Creating /Users/alex/.k3sup/.helm/cache/archive 
Creating /Users/alex/.k3sup/.helm/repository/repositories.yaml 
Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com 
Adding local repo with URL: http://127.0.0.1:8879/charts 
$HELM_HOME has been configured at /Users/alex/.k3sup/.helm.
Not installing Tiller due to 'client-only' flag having been set
```
