### PR TITLE
Document `--merge` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Other options for `install`:
 
 * `--skip-install` - if you already have k3s installed, you can just run this command to get the `kubeconfig`
 * `--ssh-key` - specify a specific path for the SSH key for remote login
-* `--local-path` - default is `./kubeconfig` - set the file where you want to save your cluster's `kubeconfig`.  By default
-  this file will be overwritten.  Use `--merge` to merge the new config with an existing one instead (e.g. `--local-path ~/.kube/config --merge`).
+* `--local-path` - default is `./kubeconfig` - set the file where you want to save your cluster's `kubeconfig`.  By default this file will be overwritten.
+* `--merge` - Merge config into existing file instead of overwriting (e.g. to add config to the default kubectl config, use `--local-path ~/.kube/config --merge`).
 * `--context` - default is `default` - set the name of the kubeconfig context.
 * `--ssh-port` - default is `22`, but you can specify an alternative port i.e. `2222`
 * `--k3s-extra-args` - Optional extra arguments to pass to k3s installer, wrapped in quotes, i.e. `--k3s-extra-args '--no-deploy traefik'` or `--k3s-extra-args '---docker'`.

--- a/README.md
+++ b/README.md
@@ -89,11 +89,13 @@ Other options for `install`:
 
 * `--skip-install` - if you already have k3s installed, you can just run this command to get the `kubeconfig`
 * `--ssh-key` - specify a specific path for the SSH key for remote login
-* `--local-path` - default is `./kubeconfig` - set the path into which you want to save your VM's `kubeconfig`
+* `--local-path` - default is `./kubeconfig` - set the file where you want to save your cluster's `kubeconfig`.  By default
+  this file will be overwritten.  Use `--merge` to merge the new config with an existing one instead (e.g. `--local-path ~/.kube/config --merge`).
 * `--context` - default is `default` - set the name of the kubeconfig context.
 * `--ssh-port` - default is `22`, but you can specify an alternative port i.e. `2222`
 * `--k3s-extra-args` - Optional extra arguments to pass to k3s installer, wrapped in quotes, i.e. `--k3s-extra-args '--no-deploy traefik'` or `--k3s-extra-args '---docker'`.
 * `--k3s-version` - set the specific version of k3s, i.e. `v0.9.1`
+* See even more install options by running `k3sup install --help`.
 
 * Now try the access:
 


### PR DESCRIPTION
Document how to merge your config into the default ~/.kube/config.  Also add a comment showing that the list of installation options in the README is not exhaustive, and point out how they can find more.

## Motivation and Context

See #81.  I couldn't find the answer to this on my own and raised an issue, so hopefully this will help someone else who has a similar problem.  :)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
