### PR TITLE
Add update command and improved error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,13 +8,10 @@ import (
 func main() {
 
 	cmdInstall := cmd.MakeInstall()
-
 	cmdVersion := cmd.MakeVersion()
-
 	cmdJoin := cmd.MakeJoin()
-
 	cmdApps := cmd.MakeApps()
-
+	cmdUpdate := cmd.MakeUpdate()
 	printk3supASCIIArt := cmd.PrintK3supASCIIArt
 
 	var rootCmd = &cobra.Command{
@@ -29,6 +26,7 @@ func main() {
 	rootCmd.AddCommand(cmdVersion)
 	rootCmd.AddCommand(cmdJoin)
 	rootCmd.AddCommand(cmdApps)
+	rootCmd.AddCommand(cmdUpdate)
 
 	rootCmd.Execute()
 }

--- a/pkg/cmd/chart_app.go
+++ b/pkg/cmd/chart_app.go
@@ -134,7 +134,7 @@ before using the generic helm chart installer command.`,
 chart ` + chartRepoName + ` installed.
 =======================================================================
 		
-Thank you for using k3sup!`)
+` + thanksForUsing)
 
 		return nil
 	}

--- a/pkg/cmd/inletsoperator_app.go
+++ b/pkg/cmd/inletsoperator_app.go
@@ -86,7 +86,7 @@ kubectl delete svc/nginx-1
 # Find out more at:
 # https://github.com/inlets/inlets-operator
 
-Thank you for using k3sup!`)
+` + thanksForUsing)
 
 		return nil
 	}

--- a/pkg/cmd/kubernetes_exec.go
+++ b/pkg/cmd/kubernetes_exec.go
@@ -176,7 +176,9 @@ func kubectl(parts ...string) error {
 	}
 
 	if res.ExitCode != 0 {
-		return fmt.Errorf("exit code %d", res.ExitCode)
+		return fmt.Errorf("kubectl exit code %d, stderr: %s",
+			res.ExitCode,
+			res.Stderr)
 	}
 	return nil
 }

--- a/pkg/cmd/metricsserver_app.go
+++ b/pkg/cmd/metricsserver_app.go
@@ -81,10 +81,13 @@ func makeInstallMetricsServer() *cobra.Command {
 			return err
 		}
 
-		err = kubectl("-n", namespace, "apply", "-R", "-f", outputPath)
+		applyRes, applyErr := kubectlTask("apply", "-R", "-f", outputPath)
+		if applyErr != nil {
+			return applyErr
+		}
 
-		if err != nil {
-			return err
+		if applyRes.ExitCode > 0 {
+			return fmt.Errorf("Error applying templated YAML files, error: %s", applyRes.Stderr)
 		}
 
 		fmt.Println(`=======================================================================
@@ -107,7 +110,7 @@ kubectl top node
 # Find out more at:
 # https://github.com/helm/charts/tree/master/stable/metrics-server
 
-Thank you for using k3sup!`)
+` + thanksForUsing)
 
 		return nil
 	}

--- a/pkg/cmd/nginx_app.go
+++ b/pkg/cmd/nginx_app.go
@@ -122,7 +122,7 @@ kubectl get svc nginx-ingress-controller
 # Find out more at:
 # https://github.com/helm/charts/tree/master/stable/nginx-ingress
 
-Thank you for using k3sup!`)
+` + thanksForUsing)
 
 		return nil
 	}

--- a/pkg/cmd/openfaas_app.go
+++ b/pkg/cmd/openfaas_app.go
@@ -140,10 +140,13 @@ func makeInstallOpenFaaS() *cobra.Command {
 			return err
 		}
 
-		err = kubectl("apply", "-R", "-f", outputPath)
+		applyRes, applyErr := kubectlTask("apply", "-R", "-f", outputPath)
+		if applyErr != nil {
+			return applyErr
+		}
 
-		if err != nil {
-			return err
+		if applyRes.ExitCode > 0 {
+			return fmt.Errorf("Error applying templated YAML files, error: %s", applyRes.Stderr)
 		}
 
 		fmt.Println(`=======================================================================
@@ -174,7 +177,7 @@ faas-cli store deploy figlet \
 # Find out more at:
 # https://github.com/openfaas/faas
 
-Thank you for using k3sup!`)
+` + thanksForUsing)
 
 		return nil
 	}

--- a/pkg/cmd/openfaas_app.go
+++ b/pkg/cmd/openfaas_app.go
@@ -85,7 +85,7 @@ func makeInstallOpenFaaS() *cobra.Command {
 			return err
 		}
 
-		err = kubectl("apply", "-f",
+		_, err = kubectlTask("apply", "-f",
 			"https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml")
 
 		if err != nil {
@@ -97,13 +97,17 @@ func makeInstallOpenFaaS() *cobra.Command {
 			return err
 		}
 
-		_, err = kubectlTask("-n", namespace, "create", "secret", "generic",
+		res, secretErr := kubectlTask("-n", namespace, "create", "secret", "generic",
 			"basic-auth",
 			"--from-literal=basic-auth-user=admin",
 			`--from-literal=basic-auth-password=`+pass)
 
-		if err != nil {
-			return err
+		if secretErr != nil {
+			return secretErr
+		}
+
+		if res.ExitCode != 0 {
+			fmt.Printf("[Warning] unable to create secret %s, may already exist: %s", "basic-auth", res.Stderr)
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")

--- a/pkg/cmd/openfaas_ingress_app.go
+++ b/pkg/cmd/openfaas_ingress_app.go
@@ -67,9 +67,10 @@ func makeInstallOpenFaaSIngress() *cobra.Command {
 			return err
 		}
 
-		if res.Stderr != "" {
-			log.Printf("Unable to install this application. Have you got OpenFaaS running in the openfaas namespace and cert-manager 0.11.0 or higher installed in cert-manager namespace? %s", res.Stderr)
-			return err
+		if res.ExitCode != 0 {
+			return fmt.Errorf(`Unable to apply YAML files.
+Have you got OpenFaaS running in the openfaas namespace and cert-manager 0.11.0 or higher installed in cert-manager namespace? %s`,
+				res.Stderr)
 		}
 
 		fmt.Println(`=======================================================================
@@ -99,8 +100,7 @@ kubectl describe -n openfaas Certificate openfaas-gateway
 # It may take a while to be issued by LetsEncrypt, in the meantime a 
 # self-signed cert will be installed
 
-
-Thank you for using k3sup!`)
+` + thanksForUsing)
 
 		return nil
 	}

--- a/pkg/cmd/tiller_app.go
+++ b/pkg/cmd/tiller_app.go
@@ -92,7 +92,7 @@ tiller has been installed
 
 ` + helmBinary + `
 
-Thank you for using k3sup!`)
+` + thanksForUsing)
 
 		return nil
 	}

--- a/pkg/cmd/update.go
+++ b/pkg/cmd/update.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func MakeUpdate() *cobra.Command {
+	var command = &cobra.Command{
+		Use:          "update",
+		Short:        "Print update instructions",
+		Example:      `  k3sup update`,
+		SilenceUsage: false,
+	}
+	command.Run = func(cmd *cobra.Command, args []string) {
+		fmt.Println(k3supUpdate)
+	}
+	return command
+}
+
+const k3supUpdate = `You can update k3sup with the following:
+
+# For Linux/MacOS:
+curl -SLfs https://get.k3sup.dev | sudo sh
+
+# For Windows (using Git Bash)
+curl -SLfs https://get.k3sup.dev | sh
+
+# Or download from GitHub: https://github.com/alexellis/k3sup/releases
+
+Thanks for using k3sup!`
+
+const thanksForUsing = `Thanks for using k3sup!`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add update command and improved error handling

Print warning if secret already exists for OpenFaaS

Return stderr when kubectl gives non-zero exit-code

## Motivation and Context

Improved error handling and dev-ex via `update` command.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually using `k3sup app install openfaas`:

```
exec:  kubectl -n openfaas create secret generic basic-auth --from-literal=basic-auth-user=admin --from-literal=basic-auth-password=<redacted>
res: 
[Warning] unable to create secret basic-auth, may already exist: Error from server (AlreadyExists): secrets "basic-auth" already exists
```

Running `k3sup update`:

```
You can update k3sup with the following:

# For Linux/MacOS:
curl -SLfs https://get.k3sup.dev | sudo sh

# For Windows (using Git Bash)
curl -SLfs https://get.k3sup.dev | sh

# Or download from GitHub: https://github.com/alexellis/k3sup/releases

Thanks for using k3sup!
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
