### PR TITLE
Remove default backend from ingress-nginx installation

### DIFF
--- a/pkg/cmd/nginx_app.go
+++ b/pkg/cmd/nginx_app.go
@@ -73,6 +73,8 @@ func makeInstallNginx() *cobra.Command {
 
 		overrides := map[string]string{}
 
+		overrides["defaultBackend.enabled"] = "false"
+
 		hostMode, flagErr := command.Flags().GetBool("host-mode")
 		if flagErr != nil {
 			return flagErr
@@ -114,7 +116,7 @@ func makeInstallNginx() *cobra.Command {
 # If you're using a local environment such as "minikube" or "KinD",
 # then try the inlets operator with "k3sup app install inlets-operator"
 
-# If you're using a managed Kubernetes service, then you'll find 
+# If you're using a managed Kubernetes service, then you'll find
 # your LoadBalancer's IP under "EXTERNAL-IP" via:
 
 kubectl get svc nginx-ingress-controller


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Default backend requirement was removed in 0.21 https://github.com/kubernetes/ingress-nginx/pull/3196

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Removes an unnecessary deployment

<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
