### PR TITLE
Add local install mode for k3sup install

### DIFF
--- a/pkg/cmd/join.go
+++ b/pkg/cmd/join.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	config "github.com/alexellis/k3sup/pkg/config"
-	kssh "github.com/alexellis/k3sup/pkg/ssh"
+	operator "github.com/alexellis/k3sup/pkg/operator"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
@@ -86,7 +86,7 @@ func MakeJoin() *cobra.Command {
 		}
 
 		address := fmt.Sprintf("%s:%d", serverIP.String(), serverPort)
-		operator, err := kssh.NewSSHOperator(address, config)
+		operator, err := operator.NewSSHOperator(address, config)
 
 		if err != nil {
 			return errors.Wrapf(err, "unable to connect to %s over ssh", address)
@@ -153,7 +153,7 @@ func setupAgent(serverIP, ip net.IP, port int, user, sshKeyPath, joinToken, k3sE
 	}
 
 	address := fmt.Sprintf("%s:%d", ip.String(), port)
-	operator, err := kssh.NewSSHOperator(address, config)
+	operator, err := operator.NewSSHOperator(address, config)
 
 	if err != nil {
 		return errors.Wrapf(err, "unable to connect to %s over ssh", address)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -1,0 +1,31 @@
+package ssh
+
+import (
+	goexecute "github.com/alexellis/go-execute/pkg/v1"
+)
+
+type CommandOperator interface {
+	Execute(command string) (CommandRes, error)
+}
+
+type ExecOperator struct {
+}
+
+func (ex ExecOperator) Execute(command string) (CommandRes, error) {
+
+	task := goexecute.ExecTask{
+		Command: command,
+		Shell:   true,
+	}
+
+	res, err := task.Execute()
+	if err != nil {
+		return CommandRes{}, err
+	}
+
+	return CommandRes{
+		StdErr: []byte(res.Stderr),
+		StdOut: []byte(res.Stdout),
+	}, nil
+
+}

--- a/pkg/operator/ssh.go
+++ b/pkg/operator/ssh.go
@@ -13,7 +13,7 @@ type SSHOperator struct {
 	conn *ssh.Client
 }
 
-func (s *SSHOperator) Close() error {
+func (s SSHOperator) Close() error {
 
 	return s.conn.Close()
 }
@@ -31,18 +31,18 @@ func NewSSHOperator(address string, config *ssh.ClientConfig) (*SSHOperator, err
 	return &operator, nil
 }
 
-func (s *SSHOperator) Execute(command string) (commandRes, error) {
+func (s SSHOperator) Execute(command string) (CommandRes, error) {
 
 	sess, err := s.conn.NewSession()
 	if err != nil {
-		return commandRes{}, err
+		return CommandRes{}, err
 	}
 
 	defer sess.Close()
 
 	sessStdOut, err := sess.StdoutPipe()
 	if err != nil {
-		return commandRes{}, err
+		return CommandRes{}, err
 	}
 
 	output := bytes.Buffer{}
@@ -57,7 +57,7 @@ func (s *SSHOperator) Execute(command string) (commandRes, error) {
 	}()
 	sessStderr, err := sess.StderrPipe()
 	if err != nil {
-		return commandRes{}, err
+		return CommandRes{}, err
 	}
 
 	errorOutput := bytes.Buffer{}
@@ -73,21 +73,21 @@ func (s *SSHOperator) Execute(command string) (commandRes, error) {
 	wg.Wait()
 
 	if err != nil {
-		return commandRes{}, err
+		return CommandRes{}, err
 	}
 
-	return commandRes{
+	return CommandRes{
 		StdErr: errorOutput.Bytes(),
 		StdOut: output.Bytes(),
 	}, nil
 }
 
-type commandRes struct {
+type CommandRes struct {
 	StdOut []byte
 	StdErr []byte
 }
 
-func executeCommand(cmd string) (commandRes, error) {
+func executeCommand(cmd string) (CommandRes, error) {
 
-	return commandRes{}, nil
+	return CommandRes{}, nil
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add local install mode for k3sup install

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

This feature allows the k3sup binary to be used to install k3s
within cloud-init, through bash, or for general local usage
without needing to pass through ssh.

Closes: #2

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested against a Civo Ubuntu node both remotely and with an
IP given. The new flag is --local.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
