### PR TITLE
Initialise a cluster with dqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ k3sup install --ip $IP --user ubuntu
 
 Other options for `install`:
 
+* `--cluster` - start this server in clustering mode, for use with dqlite (embedded HA)
 * `--skip-install` - if you already have k3s installed, you can just run this command to get the `kubeconfig`
 * `--ssh-key` - specify a specific path for the SSH key for remote login
 * `--local-path` - default is `./kubeconfig` - set the file where you want to save your cluster's `kubeconfig`.  By default this file will be overwritten.
@@ -177,6 +178,50 @@ k3sup join --ip $AGENT_IP --server-ip $SERVER_IP --user $USER
 ```
 
 That's all, so with the above command you can have a two-node cluster up and running, whether that's using VMs on-premises, using Raspberry Pis, 64-bit ARM or even cloud VMs on EC2.
+
+### Create a multi-master (HA) setup
+
+As of k3s 1.0 a HA multi-master configuration is available through dqlite. A quorum of masters will be required, which means having at least three nodes.
+
+* Initialize the cluster with the first server
+
+Note the `--cluster` flag
+
+```sh
+export SERVER_IP=192.168.0.100
+export USER=root
+
+k3sup install \
+  --ip $SERVER_IP \
+  --user $USER \
+  --cluster
+```
+
+* Join each additional server
+
+> Note the new `--server` flag
+
+```sh
+export USER=root
+export SERVER_IP=192.168.0.100
+export NEXT_SERVER_IP=192.168.0.101
+
+k3sup join \
+  --ip $NEXT_SERVER_IP \
+  --user $USER \
+  --server-user $USER \
+  --server-ip $SERVER_IP \
+  --server
+```
+
+Now check `kubectl get node`:
+
+```sh
+kubectl get node
+NAME              STATUS   ROLES    AGE     VERSION
+paprika-gregory   Ready    master   8m27s   v1.16.3-k3s.2
+cave-sensor       Ready    master   27m     v1.16.3-k3s.2
+```
 
 ### 👨‍💻 Micro-tutorial for Raspberry Pi (2, 3, or 4) 🥧
 

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -46,6 +46,7 @@ func MakeInstall() *cobra.Command {
 	command.Flags().String("k3s-version", config.K3sVersion, "Optional version to install, pinned at a default")
 
 	command.Flags().Bool("local", false, "Perform a local install without using ssh")
+	command.Flags().Bool("cluster", false, "Form a dqlite cluster")
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 
@@ -66,7 +67,16 @@ func MakeInstall() *cobra.Command {
 
 		ip, _ := command.Flags().GetIP("ip")
 
-		installK3scommand := fmt.Sprintf("curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --tls-san %s %s' INSTALL_K3S_VERSION='%s' sh -\n", ip, strings.TrimSpace(k3sExtraArgs), k3sVersion)
+		cluster, _ := command.Flags().GetBool("cluster")
+
+		clusterStr := ""
+		if cluster {
+			clusterStr = "--cluster-init"
+		}
+
+		installk3sExec := fmt.Sprintf("INSTALL_K3S_EXEC='server %s --tls-san %s %s'", clusterStr, ip, strings.TrimSpace(k3sExtraArgs))
+
+		installK3scommand := fmt.Sprintf("curl -sLS https://get.k3s.io | %s INSTALL_K3S_VERSION='%s' sh -\n", installk3sExec, k3sVersion)
 		getConfigcommand := fmt.Sprintf(sudoPrefix + "cat /etc/rancher/k3s/k3s.yaml\n")
 		merge, _ := command.Flags().GetBool("merge")
 		context, _ := command.Flags().GetString("context")

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -50,6 +50,8 @@ func MakeInstall() *cobra.Command {
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 
+		fmt.Printf("Running: k3sup install\n")
+
 		localKubeconfig, _ := command.Flags().GetString("local-path")
 
 		skipInstall, _ := command.Flags().GetBool("skip-install")
@@ -114,7 +116,7 @@ func MakeInstall() *cobra.Command {
 		sshKey, _ := command.Flags().GetString("ssh-key")
 
 		sshKeyPath := expandPath(sshKey)
-		fmt.Printf("ssh -i %s %s@%s\n", sshKeyPath, user, ip.String())
+		fmt.Printf("ssh -i %s -p %d %s@%s\n", sshKeyPath, port, user, ip.String())
 
 		authMethod, closeSSHAgent, err := loadPublickey(sshKeyPath)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Initialise a cluster with dqlite

## Motivation and Context

Fixes: #93 

Adds the --cluster flag which passes --cluster-init to k3s
under the hood.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This worked on a 64-bit machine but did not
work on armhf and I've raised an upstream issue.

The k3s maintainers believe this to be an issue with dqlite.

https://github.com/rancher/k3s/issues/1155

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

