### PR TITLE
Add `--ipsec` option to the installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ Other options for `install`:
 * `--merge` - Merge config into existing file instead of overwriting (e.g. to add config to the default kubectl config, use `--local-path ~/.kube/config --merge`).
 * `--context` - default is `default` - set the name of the kubeconfig context.
 * `--ssh-port` - default is `22`, but you can specify an alternative port i.e. `2222`
-* `--k3s-extra-args` - Optional extra arguments to pass to k3s installer, wrapped in quotes, i.e. `--k3s-extra-args '--no-deploy traefik'` or `--k3s-extra-args '--docker'`. For multiple args combine then within single quotes `--k3s-extra-args '--no-deploy traefik --docker'`.  
+* `--k3s-extra-args` - Optional extra arguments to pass to k3s installer, wrapped in quotes, i.e. `--k3s-extra-args '--no-deploy traefik'` or `--k3s-extra-args '--docker'`. For multiple args combine then within single quotes `--k3s-extra-args '--no-deploy traefik --docker'`.
 * `--k3s-version` - set the specific version of k3s, i.e. `v0.9.1`
+- `--ipsec` - Enforces the optional extra argument for k3s: `--flannel-backend` option: `ipsec`
 * See even more install options by running `k3sup install --help`.
 
 * Now try the access:

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -42,6 +42,7 @@ func MakeInstall() *cobra.Command {
 	command.Flags().String("local-path", "kubeconfig", "Local path to save the kubeconfig file")
 	command.Flags().String("context", "default", "Set the name of the kubeconfig context.")
 	command.Flags().String("k3s-extra-args", "", "Optional extra arguments to pass to k3s installer, wrapped in quotes (e.g. --k3s-extra-args '--no-deploy servicelb')")
+	command.Flags().Bool("ipsec", false, "Enforces and/or activates optional extra argument for k3s: flannel-backend option: ipsec")
 	command.Flags().Bool("merge", false, "Merge the config with existing kubeconfig if it already exists.\nProvide the --local-path flag with --merge if a kubeconfig already exists in some other directory")
 	command.Flags().String("k3s-version", config.K3sVersion, "Optional version to install, pinned at a default")
 
@@ -64,6 +65,7 @@ func MakeInstall() *cobra.Command {
 
 		k3sVersion, _ := command.Flags().GetString("k3s-version")
 		k3sExtraArgs, _ := command.Flags().GetString("k3s-extra-args")
+		flannelIPSec, _ := command.Flags().GetBool("ipsec")
 
 		local, _ := command.Flags().GetBool("local")
 
@@ -74,6 +76,10 @@ func MakeInstall() *cobra.Command {
 		clusterStr := ""
 		if cluster {
 			clusterStr = "--cluster-init"
+		}
+
+		if flannelIPSec {
+			k3sExtraArgs += ` '--flannel-backend ipsec'`
 		}
 
 		installk3sExec := fmt.Sprintf("INSTALL_K3S_EXEC='server %s --tls-san %s %s'", clusterStr, ip, strings.TrimSpace(k3sExtraArgs))


### PR DESCRIPTION
Signed-off-by: Christian Melgarejo Bresanovich <cmelgarejo.dev@gmail.com>

## Description

Adds the optional flag for activating the `--flannel-backend ipsec` option

## Motivation and Context
This feature enables the ipsec backend for Flannel in the k3sup install command
An additional flag to k3sup install should enable ipsec for Flannel as per Darren's comment (@ibuildthecloud) here -> https://twitter.com/ibuildthecloud/status/1200119925500592129

- [x] There is an issue to propose this change ([#116](https://github.com/alexellis/k3sup/issues/116))


## How Has This Been Tested?

- k3sup install --ipsec
- k3sup join

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
