### PR TITLE
Make kubeconfig flag persistant for the app install command

### DIFF
--- a/pkg/cmd/apps.go
+++ b/pkg/cmd/apps.go
@@ -26,7 +26,7 @@ func MakeApps() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	install.Flags().String("kubeconfig", "kubeconfig", "Local path for your kubeconfig file")
+	install.PersistentFlags().String("kubeconfig", "kubeconfig", "Local path for your kubeconfig file")
 
 	install.RunE = func(command *cobra.Command, args []string) error {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This allows users to specify the location of the kubeconfig file
to be used when running an app install command for any of the apps.

Because the flag is persistant, it can be placed anywhere in the command
after the 'install' command.

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
This was raised in a Slack conversation. The conversation is copied below for reference:

> Burton Rheutan
Has anyone used the --kubeconfig flag on the app command?
I was trying to use it this evening with no luck:
$ ./k3sup app install --kubeconfig ~/micro.kubeconfig openfaas
Error: unknown flag: --kubeconfig
$ ./k3sup app install openfaas --kubeconfig ~/micro.kubeconfig
Error: unknown flag: --kubeconfig
I was able to move forward with my work by setting the env var. Should I open an issue for that?

> Burton Rheutan 
It seems the way to fix it is to add TraverseChildren: true, to each of the app commands (openfaas, nginx, etc) as well as the app (parent) command.
At least that's what worked for me...

> Burton Rheutan
Also, it should be noted that when using the TraverseChildren option, the command must be run as:
k3sup app install --kubeconfig <path to config> openfaas
However, perhaps it would be more useful to set that flag as a global flag so that it can be used anywhere in the command
rootCmd.PersistentFlags().String("kubeconfig", ...
With the global/persistent flag, the following command syntax then also works:
$ ./k3sup app install openfaas --kubeconfig ~/micro.kubeconfig

> Alex Ellis 
I'm not sure if it was intended for use that way. I'll take a look

> Alex Ellis 
I mostly use kubectx or export the env var

> Burton Rheutan
I didn't see anything explained in the readme about that flag and how it should be used.
Happy to PR either updating the flag, or updating the readme to explain how it is intended to be used

> Alex Ellis
Do you see it on k3sup app install openfaas --help?

> Alex Ellis 
Untitled 
Version: 0.6.8
Git Commit: d113ced73d825f9c3a0c465d080c80c729f368cd
kosmos:faas-cli alex$ k3sup app install openfaas --help
Install openfaas
Click to expand inline (22 lines)



> Burton Rheutan
no, but doing my normal process of stepping through the commands to learn what's available, I saw it on the install command
$k3sup --help
$k3sup app --help
$k3sup app install --help

> Alex Ellis
Ah I see now, perhaps we need to update apps.go to have install.PersistentFlags().String("kubeconfig", "kubeconfig", "Local path for your kubeconfig file") ? @burtonr (edited) 
:muscle:

Feel free to take care of it


> Alex Ellis
:+1:

> Alex Ellis
SGTM


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally installing the `nginx-ingress` app on a local microk8s cluster and viewing the `--help` output

```
$ ./k3sup app install --help
Install a Kubernetes app

Usage:
  k3sup app install [flags]
  k3sup app install [command]

Examples:
  k3sup app install [APP]
  k3sup app install openfaas --help
  k3sup app install inlets-operator --token-file $HOME/do
  k3sup app install --help

Available Commands:
  cert-manager     Install cert-manager
  chart            Install the specified helm chart
  cron-connector   Install cron-connector for OpenFaaS
  inlets-operator  Install inlets-operator
  kafka-connector  Install kafka-connector for OpenFaaS
  linkerd          Install linkerd
  metrics-server   Install metrics-server
  nginx-ingress    Install nginx-ingress
  openfaas         Install openfaas
  openfaas-ingress Install openfaas ingress with TLS
  tiller           Install tiller

Flags:
  -h, --help                help for install
      --kubeconfig string   Local path for your kubeconfig file (default "kubeconfig")

Use "k3sup app install [command] --help" for more information about a command.
```

```
$ ./k3sup app install nginx-ingress --help
Install nginx-ingress. This app can be installed with Host networking for cases where an external LB is not available. please see the --host-mode flag and the nginx-ingress docs for more info

Usage:
  k3sup app install nginx-ingress [flags]

Examples:
  k3sup app install nginx-ingress --namespace default

Flags:
  -h, --help               help for nginx-ingress
      --host-mode          If we should install nginx-ingress in host mode.
  -n, --namespace string   The namespace used for installation (default "default")
      --update-repo        Update the helm repo (default true)

Global Flags:
      --kubeconfig string   Local path for your kubeconfig file (default "kubeconfig")
```


```
$ ./k3sup app install nginx-ingress --kubeconfig ~/micro.kubeconfig 
Using kubeconfig: /home/burtonr/micro.kubeconfig
exec:  uname -m
res: x86_64

...
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
