### PR TITLE
Add helm3 support for the openfaas app

### DIFF
--- a/pkg/cmd/certmanager_app.go
+++ b/pkg/cmd/certmanager_app.go
@@ -50,12 +50,12 @@ func makeInstallCertManager() *cobra.Command {
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		_, err = tryDownloadHelm(userPath, clientArch, clientOS)
+		_, err = tryDownloadHelm(userPath, clientArch, clientOS, false)
 		if err != nil {
 			return err
 		}
 
-		err = addHelmRepo("jetstack", "https://charts.jetstack.io")
+		err = addHelmRepo("jetstack", "https://charts.jetstack.io", false)
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,7 @@ func makeInstallCertManager() *cobra.Command {
 		updateRepo, _ := certManager.Flags().GetBool("update-repo")
 
 		if updateRepo {
-			err = updateHelmRepos()
+			err = updateHelmRepos(false)
 			if err != nil {
 				return err
 			}
@@ -80,7 +80,7 @@ func makeInstallCertManager() *cobra.Command {
 
 		chartPath := path.Join(os.TempDir(), "charts")
 
-		err = fetchChart(chartPath, "jetstack/cert-manager")
+		err = fetchChart(chartPath, "jetstack/cert-manager", false)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/chart_app.go
+++ b/pkg/cmd/chart_app.go
@@ -74,19 +74,19 @@ before using the generic helm chart installer command.`,
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		_, err = tryDownloadHelm(userPath, clientArch, clientOS)
+		_, err = tryDownloadHelm(userPath, clientArch, clientOS, false)
 		if err != nil {
 			return err
 		}
 
 		if len(chartRepoURL) > 0 {
-			err = addHelmRepo(chartPrefix, chartRepoURL)
+			err = addHelmRepo(chartPrefix, chartRepoURL, false)
 			if err != nil {
 				return err
 			}
 		}
 
-		err = updateHelmRepos()
+		err = updateHelmRepos(false)
 		if err != nil {
 			return err
 		}
@@ -98,7 +98,7 @@ before using the generic helm chart installer command.`,
 
 		chartPath := path.Join(os.TempDir(), "charts")
 
-		err = fetchChart(chartPath, chartRepoName)
+		err = fetchChart(chartPath, chartRepoName, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/cronconnector_app.go
+++ b/pkg/cmd/cronconnector_app.go
@@ -52,25 +52,25 @@ func makeInstallCronConnector() *cobra.Command {
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		_, err = tryDownloadHelm(userPath, clientArch, clientOS)
+		_, err = tryDownloadHelm(userPath, clientArch, clientOS, false)
 		if err != nil {
 			return err
 		}
 
-		err = addHelmRepo("openfaas", "https://openfaas.github.io/faas-netes/")
+		err = addHelmRepo("openfaas", "https://openfaas.github.io/faas-netes/", false)
 		if err != nil {
 			return err
 		}
 
 		if updateRepo {
-			err = updateHelmRepos()
+			err = updateHelmRepos(false)
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "openfaas/cron-connector")
+		err = fetchChart(chartPath, "openfaas/cron-connector", false)
 
 		if err != nil {
 			return err

--- a/pkg/cmd/inletsoperator_app.go
+++ b/pkg/cmd/inletsoperator_app.go
@@ -63,12 +63,12 @@ func makeInstallInletsOperator() *cobra.Command {
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		_, err = tryDownloadHelm(userPath, clientArch, clientOS)
+		_, err = tryDownloadHelm(userPath, clientArch, clientOS, false)
 		if err != nil {
 			return err
 		}
 
-		err = addHelmRepo("inlets", "https://inlets.github.io/inlets-operator/")
+		err = addHelmRepo("inlets", "https://inlets.github.io/inlets-operator/", false)
 		if err != nil {
 			return err
 		}
@@ -76,7 +76,7 @@ func makeInstallInletsOperator() *cobra.Command {
 		updateRepo, _ := inletsOperator.Flags().GetBool("update-repo")
 
 		if updateRepo {
-			err = updateHelmRepos()
+			err = updateHelmRepos(false)
 			if err != nil {
 				return err
 			}
@@ -84,7 +84,7 @@ func makeInstallInletsOperator() *cobra.Command {
 
 		chartPath := path.Join(os.TempDir(), "charts")
 
-		err = fetchChart(chartPath, "inlets/inlets-operator")
+		err = fetchChart(chartPath, "inlets/inlets-operator", false)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/kafkaconnector_app.go
+++ b/pkg/cmd/kafkaconnector_app.go
@@ -54,25 +54,25 @@ func makeInstallKafkaConnector() *cobra.Command {
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		_, err = tryDownloadHelm(userPath, clientArch, clientOS)
+		_, err = tryDownloadHelm(userPath, clientArch, clientOS, false)
 		if err != nil {
 			return err
 		}
 
-		err = addHelmRepo("openfaas", "https://openfaas.github.io/faas-netes/")
+		err = addHelmRepo("openfaas", "https://openfaas.github.io/faas-netes/", false)
 		if err != nil {
 			return err
 		}
 
 		if updateRepo {
-			err = updateHelmRepos()
+			err = updateHelmRepos(false)
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "openfaas/kafka-connector")
+		err = fetchChart(chartPath, "openfaas/kafka-connector", false)
 
 		if err != nil {
 			return err

--- a/pkg/cmd/linkerd_app.go
+++ b/pkg/cmd/linkerd_app.go
@@ -141,7 +141,7 @@ func downloadLinkerd(userPath, clientOS string) error {
 
 func linkerdCli(parts ...string) (execute.ExecResult, error) {
 	task := execute.ExecTask{
-		Command: fmt.Sprintf("%s", localBinary("linkerd")),
+		Command: fmt.Sprintf("%s", localBinary("linkerd", "")),
 		Args:    parts,
 		Env:     os.Environ(),
 	}

--- a/pkg/cmd/metricsserver_app.go
+++ b/pkg/cmd/metricsserver_app.go
@@ -48,18 +48,18 @@ func makeInstallMetricsServer() *cobra.Command {
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		_, err = tryDownloadHelm(userPath, clientArch, clientOS)
+		_, err = tryDownloadHelm(userPath, clientArch, clientOS, false)
 		if err != nil {
 			return err
 		}
 
-		err = updateHelmRepos()
+		err = updateHelmRepos(false)
 		if err != nil {
 			return err
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "stable/metrics-server")
+		err = fetchChart(chartPath, "stable/metrics-server", false)
 
 		if err != nil {
 			return err

--- a/pkg/cmd/minio_app.go
+++ b/pkg/cmd/minio_app.go
@@ -57,20 +57,20 @@ func makeInstallMinio() *cobra.Command {
 			return fmt.Errorf("please use the helm chart if you'd like to change the namespace to %s", ns)
 		}
 
-		_, err = tryDownloadHelm(userPath, clientArch, clientOS)
+		_, err = tryDownloadHelm(userPath, clientArch, clientOS, false)
 		if err != nil {
 			return err
 		}
 
 		if updateRepo {
-			err = updateHelmRepos()
+			err = updateHelmRepos(false)
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "stable/minio")
+		err = fetchChart(chartPath, "stable/minio", false)
 
 		if err != nil {
 			return err

--- a/pkg/cmd/nginx_app.go
+++ b/pkg/cmd/nginx_app.go
@@ -52,20 +52,20 @@ func makeInstallNginx() *cobra.Command {
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		_, err = tryDownloadHelm(userPath, clientArch, clientOS)
+		_, err = tryDownloadHelm(userPath, clientArch, clientOS, false)
 		if err != nil {
 			return err
 		}
 
 		if updateRepo {
-			err = updateHelmRepos()
+			err = updateHelmRepos(false)
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "stable/nginx-ingress")
+		err = fetchChart(chartPath, "stable/nginx-ingress", false)
 
 		if err != nil {
 			return err

--- a/pkg/cmd/tiller_app.go
+++ b/pkg/cmd/tiller_app.go
@@ -79,7 +79,7 @@ func makeInstallTiller() *cobra.Command {
 
 		fmt.Println(res.Stdout, res.Stderr)
 
-		helmBinary, err := tryDownloadHelm(userPath, clientArch, clientOS)
+		helmBinary, err := tryDownloadHelm(userPath, clientArch, clientOS, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add helm3 support for the openfaas app

## Motivation and Context

Helm3 support can be gained through the --helm3 flag. The
download and utility methods for working with helm are now
version aware.

#107 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by installing openfaas with and without the --helm3 flag
and looking at the containers in the openfaas namespace. I also
installed the Minio app to make sure existing apps did not
get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Helm 2:

```sh
go build && ./k3sup app install openfaas --helm3=false
Using kubeconfig: /Users/alex/.config/k3d/k3s-default/kubeconfig.yaml
exec:  kubectl get nodes --output jsonpath={range $.items[0]}{.status.nodeInfo.architecture}
res: amd64
Node architecture: "amd64"
exec:  uname -m
res: x86_64

exec:  uname -s
res: Darwin

Client: "x86_64", "Darwin"
2019/12/10 10:33:33 User dir established as: /Users/alex/.k3sup/
https://get.helm.sh/helm-v2.16.0-darwin-amd64.tar.gz
/Users/alex/.k3sup/bin/darwin-amd64 darwin-amd64/
/Users/alex/.k3sup/bin/README.md darwin-amd64/README.md
/Users/alex/.k3sup/bin/helm darwin-amd64/helm
/Users/alex/.k3sup/bin/LICENSE darwin-amd64/LICENSE
/Users/alex/.k3sup/bin/tiller darwin-amd64/tiller
2019/12/10 10:33:36 extracted tarball into /Users/alex/.k3sup/bin: 4 files, 0 dirs (1.985035118s)
exec:  /Users/alex/.k3sup/bin/helm init --client-only
res: Creating /Users/alex/.k3sup/.helm/repository 
Creating /Users/alex/.k3sup/.helm/repository/cache 
Creating /Users/alex/.k3sup/.helm/repository/local 
Creating /Users/alex/.k3sup/.helm/plugins 
Creating /Users/alex/.k3sup/.helm/starters 
Creating /Users/alex/.k3sup/.helm/cache/archive 
Creating /Users/alex/.k3sup/.helm/repository/repositories.yaml 
Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com 
Adding local repo with URL: http://127.0.0.1:8879/charts 
$HELM_HOME has been configured at /Users/alex/.k3sup/.helm.
Not installing Tiller due to 'client-only' flag having been set

exec:  /Users/alex/.k3sup/bin/helm repo add openfaas https://openfaas.github.io/faas-netes/ 
res: "openfaas" has been added to your repositories

exec:  /Users/alex/.k3sup/bin/helm repo update 
res: Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete.

exec:  kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
res: namespace/openfaas unchanged
namespace/openfaas-fn unchanged

exec:  kubectl -n openfaas create secret generic basic-auth --from-literal=basic-auth-user=admin --from-literal=basic-auth-password=qM53W9HJRX4YqNVR7K98646Uk
res: 
[Warning] unable to create secret basic-auth, may already exist: Error from server (AlreadyExists): secrets "basic-auth" already exists
exec:  /Users/alex/.k3sup/bin/helm fetch openfaas/openfaas --untar --untardir /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts 
res: 
exec:  /Users/alex/.k3sup/bin/helm template openfaas --name openfaas --namespace openfaas --output-dir /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered --values /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/values.yaml  --set basicAuthPlugin.replicas=1 --set basic_auth=true --set serviceType=NodePort --set clusterRole=false --set gateway.directFunctions=true --set operator.create=false --set openfaasImagePullPolicy=IfNotPresent --set faasnetes.imagePullPolicy=IfNotPresent 
res: wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/alertmanager-cfg.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/prometheus-cfg.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/controller-rbac.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/prometheus-rbac.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/alertmanager-svc.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/basic-auth-plugin-svc.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/gateway-external-svc.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/gateway-svc.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/nats-svc.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/prometheus-svc.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/alertmanager-dep.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/basic-auth-plugin-dep.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/faas-idler-dep.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/gateway-dep.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/nats-dep.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/prometheus-dep.yaml
wrote /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered/openfaas/templates/queueworker-dep.yaml

exec:  kubectl apply -R -f /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/rendered
res: configmap/alertmanager-config unchanged
deployment.apps/alertmanager unchanged
service/alertmanager unchanged
deployment.apps/basic-auth-plugin unchanged
service/basic-auth-plugin unchanged
serviceaccount/openfaas-controller unchanged
role.rbac.authorization.k8s.io/openfaas-controller unchanged
rolebinding.rbac.authorization.k8s.io/openfaas-controller unchanged
deployment.apps/faas-idler unchanged
deployment.apps/gateway configured
service/gateway-external unchanged
service/gateway unchanged
deployment.apps/nats unchanged
service/nats unchanged
configmap/prometheus-config unchanged
deployment.apps/prometheus unchanged
serviceaccount/openfaas-prometheus unchanged
role.rbac.authorization.k8s.io/openfaas-prometheus unchanged
rolebinding.rbac.authorization.k8s.io/openfaas-prometheus unchanged
service/prometheus unchanged
deployment.apps/queue-worker unchanged

=======================================================================
= OpenFaaS has been installed.                                        =
=======================================================================

# Get the faas-cli
curl -SLsf https://cli.openfaas.com | sudo sh

# Forward the gateway to your machine
kubectl rollout status -n openfaas deploy/gateway
kubectl port-forward -n openfaas svc/gateway 8080:8080 &

# If basic auth is enabled, you can now log into your gateway:
PASSWORD=$(kubectl get secret -n openfaas basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode; echo)
echo -n $PASSWORD | faas-cli login --username admin --password-stdin

faas-cli store deploy figlet
faas-cli list

# For Raspberry Pi
faas-cli store list \
 --platform armhf

faas-cli store deploy figlet \
 --platform armhf

# Find out more at:
# https://github.com/openfaas/faas

Thanks for using k3sup!
```

Helm 3:

```sh
go build && ./k3sup app install openfaas --helm3
Using kubeconfig: /Users/alex/.config/k3d/k3s-default/kubeconfig.yaml
Using helm3
exec:  kubectl get nodes --output jsonpath={range $.items[0]}{.status.nodeInfo.architecture}
res: amd64
Node architecture: "amd64"
exec:  uname -m
res: x86_64

exec:  uname -s
res: Darwin

Client: "x86_64", "Darwin"
2019/12/10 10:39:40 User dir established as: /Users/alex/.k3sup/
https://get.helm.sh/helm-v3.0.1-darwin-amd64.tar.gz
/Users/alex/.k3sup/bin/helm3/darwin-amd64 darwin-amd64/
/Users/alex/.k3sup/bin/helm3/LICENSE darwin-amd64/LICENSE
/Users/alex/.k3sup/bin/helm3/README.md darwin-amd64/README.md
/Users/alex/.k3sup/bin/helm3/helm darwin-amd64/helm
2019/12/10 10:39:41 extracted tarball into /Users/alex/.k3sup/bin/helm3: 3 files, 0 dirs (955.993382ms)
exec:  /Users/alex/.k3sup/bin/helm3/helm repo add openfaas https://openfaas.github.io/faas-netes/ 
res: "openfaas" has been added to your repositories

exec:  /Users/alex/.k3sup/bin/helm3/helm repo update 
res: Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "openfaas" chart repository
Update Complete. ⎈ Happy Helming!⎈ 

exec:  kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
res: namespace/openfaas created
namespace/openfaas-fn created

exec:  kubectl -n openfaas create secret generic basic-auth --from-literal=basic-auth-user=admin --from-literal=basic-auth-password=h44lQsg061723adM2h0ITeMat
res: secret/basic-auth created

exec:  /Users/alex/.k3sup/bin/helm3/helm fetch openfaas/openfaas --untar --untardir /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts 
res: 
exec:  /Users/alex/.k3sup/bin/helm3/helm upgrade --install openfaas openfaas/openfaas --namespace openfaas --values /var/folders/kk/7ds650y150j3b5q_t_k3q8gc0000gn/T/charts/openfaas/values.yaml --set operator.create=false --set openfaasImagePullPolicy=IfNotPresent --set faasnetes.imagePullPolicy=IfNotPresent --set basicAuthPlugin.replicas=1 --set basic_auth=true --set serviceType=NodePort --set clusterRole=false --set gateway.directFunctions=true
res: Release "openfaas" does not exist. Installing it now.
NAME: openfaas
LAST DEPLOYED: Tue Dec 10 10:39:48 2019
NAMESPACE: openfaas
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
To verify that openfaas has started, run:

  kubectl --namespace=openfaas get deployments -l "release=openfaas, app=openfaas"

=======================================================================
= OpenFaaS has been installed.                                        =
=======================================================================

# Get the faas-cli
curl -SLsf https://cli.openfaas.com | sudo sh

# Forward the gateway to your machine
kubectl rollout status -n openfaas deploy/gateway
kubectl port-forward -n openfaas svc/gateway 8080:8080 &

# If basic auth is enabled, you can now log into your gateway:
PASSWORD=$(kubectl get secret -n openfaas basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode; echo)
echo -n $PASSWORD | faas-cli login --username admin --password-stdin

faas-cli store deploy figlet
faas-cli list

# For Raspberry Pi
faas-cli store list \
 --platform armhf

faas-cli store deploy figlet \
 --platform armhf

# Find out more at:
# https://github.com/openfaas/faas

Thanks for using k3sup!
```