### PR TITLE
Add Kubernetes-dashboard app and instructions

### DIFF
--- a/pkg/cmd/apps.go
+++ b/pkg/cmd/apps.go
@@ -52,6 +52,7 @@ func MakeApps() *cobra.Command {
 	install.AddCommand(makeInstallKafkaConnector())
 	install.AddCommand(makeInstallMinio())
 	install.AddCommand(makeInstallPostgresql())
+	install.AddCommand(makeInstallKubernetesDashboard())
 
 	return command
 }
@@ -60,5 +61,5 @@ func getApps() []string {
 	return []string{"openfaas", "nginx-ingress", "cert-manager",
 		"openfaas-ingress", "inlets-operator", "metrics-server",
 		"chart", "tiller", "linkerd", "cron-connector",
-		"kafka-connector", "minio", "postgresql"}
+		"kafka-connector", "minio", "postgresql, kubernetes-dashboard"}
 }

--- a/pkg/cmd/kubernetes_dashboard.go
+++ b/pkg/cmd/kubernetes_dashboard.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+func makeInstallKubernetesDashboard() *cobra.Command {
+	var kubeDashboard = &cobra.Command{
+		Use:          "kubernetes-dashboard",
+		Short:        "Install kubernetes-dashboard",
+		Long:         `Install kubernetes-dashboard`,
+		Example:      `  k3sup app install kubernetes-dashboard`,
+		SilenceUsage: true,
+	}
+
+
+	kubeDashboard.RunE = func(command *cobra.Command, args []string) error {
+		kubeConfigPath := getDefaultKubeconfig()
+
+		if command.Flags().Changed("kubeconfig") {
+			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
+		}
+
+		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
+
+		arch := getArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+
+		_, err := kubectlTask("apply", "-f",
+			"https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta6/aio/deploy/recommended.yaml")
+		if err != nil {
+			return err
+		}
+		_, err = kubectlTask("apply", "-",
+			`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard`)
+		if err != nil {
+			return err
+		}
+
+		_, err = kubectlTask("apply", "-",
+			`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: admin-user
+  namespace: kubernetes-dashboard`)
+		if err != nil {
+			return err
+		}
+
+
+
+		fmt.Println(`=======================================================================
+= Kubernetes Dashboard has been installed.                                        =
+=======================================================================
+
+#To forward the dashboard to your local machine 
+kubectl proxy
+
+#To get your Token for logging in
+kubectl -n kubernetes-dashboard describe secret $(kubectl -n kubernetes-dashboard get secret | grep default-token | awk '{print $1}')
+
+# Once Proxying you can navigate to the below
+http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/login
+
+` + thanksForUsing)
+
+		return nil
+	}
+
+	return kubeDashboard
+}


### PR DESCRIPTION
This adds the kubernetes-dashboard to the app


closes #125

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#125 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Installed on an x86 k3d cluster (clean cluster will nothing else installed)
The supported arches are: 
<img width="517" alt="Screenshot 2019-12-11 at 14 44 45" src="https://user-images.githubusercontent.com/40488132/70631303-e71c1880-1c24-11ea-87c3-19c73867b352.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
