### PR TITLE
Fix chart app creating namespace even if exists

### DIFF
--- a/pkg/cmd/chart_app.go
+++ b/pkg/cmd/chart_app.go
@@ -91,9 +91,17 @@ before using the generic helm chart installer command.`,
 			return err
 		}
 
-		err = kubectl("create", "namespace", namespace)
-		if err != nil {
+		res, kcErr := kubectlTask("get", "namespace", namespace)
+
+		if kcErr != nil {
 			return err
+		}
+
+		if res.ExitCode != 0 {
+			err = kubectl("create", "namespace", namespace)
+			if err != nil {
+				return err
+			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")

--- a/pkg/cmd/kubernetes_dashboard.go
+++ b/pkg/cmd/kubernetes_dashboard.go
@@ -14,7 +14,6 @@ func makeInstallKubernetesDashboard() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-
 	kubeDashboard.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
 
@@ -58,8 +57,6 @@ subjects:
 		if err != nil {
 			return err
 		}
-
-
 
 		fmt.Println(`=======================================================================
 = Kubernetes Dashboard has been installed.                                        =


### PR DESCRIPTION
## Description
The chart app (installs chart without tiller)
was trying too create the namespace passed in
(or default if not set) even if it existed,
this gave an error so the command failed
instead of skipping if namespace exists and installing

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

closes #128 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#128 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New k3d cluster, before the fix installing like this : `k3sup app install chart --repo-name stable/nginx-ingress` failed because it tried to create the default namespace.

Now running that command ( without a namespase set) works.

Supplying a specific namespace still works too, and if that namespace already exists then it still works:
`./k3sup app install chart --repo-name stable/nginx-ingress -n this-ns` works first time

`kubectl create namespace other-ns`
`./k3sup app install chart --repo-name stable/nginx-ingress -n other-ns`

works too.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
