### PR TITLE
Add replicas for queue-worker/gateway for OpenFaaS

### DIFF
--- a/pkg/cmd/openfaas_app.go
+++ b/pkg/cmd/openfaas_app.go
@@ -35,6 +35,9 @@ func makeInstallOpenFaaS() *cobra.Command {
 	openfaas.Flags().Bool("clusterrole", false, "Create a ClusterRole for OpenFaaS instead of a limited scope Role")
 	openfaas.Flags().Bool("direct-functions", true, "Invoke functions directly from the gateway")
 
+	openfaas.Flags().Int("queue-workers", 1, "Replicas of queue-worker")
+	openfaas.Flags().Int("gateways", 1, "Replicas of gateway")
+
 	openfaas.Flags().Bool("helm3", false, "Use helm3 instead of the default helm2")
 
 	openfaas.RunE = func(command *cobra.Command, args []string) error {
@@ -162,11 +165,12 @@ func makeInstallOpenFaaS() *cobra.Command {
 		}
 
 		directFunctions, _ := command.Flags().GetBool("direct-functions")
-
 		directFunctionsVal := "true"
 		if !directFunctions {
 			directFunctionsVal = "false"
 		}
+		gateways, _ := command.Flags().GetInt("gateways")
+		queueWorkers, _ := command.Flags().GetInt("queue-workers")
 
 		overrides["clusterRole"] = clusterRoleVal
 		overrides["gateway.directFunctions"] = directFunctionsVal
@@ -174,6 +178,8 @@ func makeInstallOpenFaaS() *cobra.Command {
 		overrides["openfaasImagePullPolicy"] = pullPolicy
 		overrides["faasnetes.imagePullPolicy"] = functionPullPolicy
 		overrides["basicAuthPlugin.replicas"] = "1"
+		overrides["gateway.replicas"] = fmt.Sprintf("%d", gateways)
+		overrides["queueWorker.replicas"] = fmt.Sprintf("%d", queueWorkers)
 
 		basicAuth, _ := command.Flags().GetBool("basic-auth")
 


### PR DESCRIPTION

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

* Allows --gateways and --queue-workers to be set to configure
replicas.

## Motivation and Context

Additional configuration for OpenFaaS users

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with k3d, I saw the expected amount of Pods come up

```
go build && ./k3sup app install openfaas --queue-workers 4 --gateways 2
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
