### PR TITLE
Add app info subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,21 @@ Apps that you can install today:
 
 Want to request an app? [Raise an issue](https://github.com/alexellis/k3sup/issues) or let me know on [Slack](https://slack.openfaas.io).
 
+You can also find about how to use the app after installation by using
+
+```sh
+k3sup app info openfaas
+k3sup app info inlets-operator
+```
+
+Find out more with
+
+```sh
+k3sup app info --help
+# To know for which apps you can get info
+k3sup app info
+```
+
 ### 😸 Join some agents to your Kubernetes server
 
 Let's say that you have a server, and have already run the following:

--- a/pkg/cmd/apps.go
+++ b/pkg/cmd/apps.go
@@ -9,10 +9,11 @@ import (
 
 func MakeApps() *cobra.Command {
 	var command = &cobra.Command{
-		Use:          "app",
-		Short:        "Manage Kubernetes apps",
-		Long:         `Manage Kubernetes apps`,
-		Example:      `  k3sup app install`,
+		Use:   "app",
+		Short: "Manage Kubernetes apps",
+		Long:  `Manage Kubernetes apps`,
+		Example: `  k3sup app install
+  k3sup app info`,
 		SilenceUsage: false,
 	}
 
@@ -38,6 +39,42 @@ func MakeApps() *cobra.Command {
 		return nil
 	}
 
+	info := &cobra.Command{
+		Use:   "info",
+		Short: "Find info about a Kubernetes app",
+		Long:  "Find info about how to use the installed Kubernetes app",
+		Example: `  k3sup app info [APP]
+  k3sup app info openfaas
+  k3sup app info inlets-operator
+  k3sup app info
+  k3sup app info --help`,
+		SilenceUsage: true,
+	}
+
+	info.RunE = func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			fmt.Println("You can get info about: openfaas, inlets-operator")
+			return nil
+		}
+
+		if len(args) != 1 {
+			return fmt.Errorf("you can only get info about exactly one installed app")
+		}
+
+		appName := args[0]
+
+		switch appName {
+		case "inlets-operator":
+			fmt.Println(inletsOperatorInfoMsg)
+		case "openfaas":
+			fmt.Println(openfaasInfoMsg)
+		default:
+			return fmt.Errorf("no info or no app available for %s", appName)
+		}
+
+		return nil
+	}
+
 	command.AddCommand(install)
 	install.AddCommand(makeInstallOpenFaaS())
 	install.AddCommand(makeInstallMetricsServer())
@@ -53,6 +90,8 @@ func MakeApps() *cobra.Command {
 	install.AddCommand(makeInstallMinio())
 	install.AddCommand(makeInstallPostgresql())
 	install.AddCommand(makeInstallKubernetesDashboard())
+
+	command.AddCommand(info)
 
 	return command
 }

--- a/pkg/cmd/inletsoperator_app.go
+++ b/pkg/cmd/inletsoperator_app.go
@@ -141,29 +141,7 @@ func makeInstallInletsOperator() *cobra.Command {
 			return fmt.Errorf("Error applying templated YAML files, error: %s", applyRes.Stderr)
 		}
 
-		fmt.Println(`=======================================================================
-= inlets-operator has been installed.                                  =
-=======================================================================
-
-# The default configuration is for DigitalOcean and your secret is
-# stored as "inlets-access-key" in the "default" namespace.
-
-# To get your first Public IP run the following:
-kubectl run nginx-1 --image=nginx --port=80 --restart=Always
-kubectl expose deployment nginx-1 --port=80 --type=LoadBalancer
-
-# Find your IP in the "EXTERNAL-IP" field, watch for "<pending>" to 
-# change to an IP
-
-kubectl get svc -w
-
-# When you're done, remove the tunnel by deleting the service
-kubectl delete svc/nginx-1
-
-# Find out more at:
-# https://github.com/inlets/inlets-operator
-
-` + thanksForUsing)
+		fmt.Println(inletsOperatorPostInstallMsg)
 
 		return nil
 	}
@@ -194,3 +172,26 @@ func getOverridesWithPlatform(command *cobra.Command) map[string]string {
 
 	return overrides
 }
+
+const inletsOperatorInfoMsg = `# The default configuration is for DigitalOcean and your secret is
+# stored as "inlets-access-key" in the "default" namespace.
+
+# To get your first Public IP run the following:
+kubectl run nginx-1 --image=nginx --port=80 --restart=Always
+kubectl expose deployment nginx-1 --port=80 --type=LoadBalancer
+
+# Find your IP in the "EXTERNAL-IP" field, watch for "<pending>" to 
+# change to an IP
+
+kubectl get svc -w
+
+# When you're done, remove the tunnel by deleting the service
+kubectl delete svc/nginx-1
+
+# Find out more at:
+# https://github.com/inlets/inlets-operator`
+
+const inletsOperatorPostInstallMsg = `=======================================================================
+= inlets-operator has been installed.                                  =
+=======================================================================` +
+	"\n\n" + inletsOperatorInfoMsg + "\n\n" + thanksForUsing

--- a/pkg/cmd/openfaas_app.go
+++ b/pkg/cmd/openfaas_app.go
@@ -223,35 +223,7 @@ func makeInstallOpenFaaS() *cobra.Command {
 			}
 		}
 
-		fmt.Println(`=======================================================================
-= OpenFaaS has been installed.                                        =
-=======================================================================
-
-# Get the faas-cli
-curl -SLsf https://cli.openfaas.com | sudo sh
-
-# Forward the gateway to your machine
-kubectl rollout status -n openfaas deploy/gateway
-kubectl port-forward -n openfaas svc/gateway 8080:8080 &
-
-# If basic auth is enabled, you can now log into your gateway:
-PASSWORD=$(kubectl get secret -n openfaas basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode; echo)
-echo -n $PASSWORD | faas-cli login --username admin --password-stdin
-
-faas-cli store deploy figlet
-faas-cli list
-
-# For Raspberry Pi
-faas-cli store list \
- --platform armhf
-
-faas-cli store deploy figlet \
- --platform armhf
-
-# Find out more at:
-# https://github.com/openfaas/faas
-
-` + thanksForUsing)
+		fmt.Println(openfaasPostInstallMsg)
 
 		return nil
 	}
@@ -273,3 +245,32 @@ func getValuesSuffix(arch string) string {
 	}
 	return valuesSuffix
 }
+
+const openfaasInfoMsg = `# Get the faas-cli
+curl -SLsf https://cli.openfaas.com | sudo sh
+
+# Forward the gateway to your machine
+kubectl rollout status -n openfaas deploy/gateway
+kubectl port-forward -n openfaas svc/gateway 8080:8080 &
+
+# If basic auth is enabled, you can now log into your gateway:
+PASSWORD=$(kubectl get secret -n openfaas basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode; echo)
+echo -n $PASSWORD | faas-cli login --username admin --password-stdin
+
+faas-cli store deploy figlet
+faas-cli list
+
+# For Raspberry Pi
+faas-cli store list \
+ --platform armhf
+
+faas-cli store deploy figlet \
+ --platform armhf
+
+# Find out more at:
+# https://github.com/openfaas/faas`
+
+const openfaasPostInstallMsg = `=======================================================================
+= OpenFaaS has been installed.                                        =
+=======================================================================` +
+	"\n\n" + openfaasInfoMsg + "\n\n" + thanksForUsing


### PR DESCRIPTION
## Description
Added `info` subcommand to `app`. Pulled out the message printed in `inlets-operator` install code, and stored the messages in variables. 

## Motivation and Context
Fixes #133 

## How Has This Been Tested?
I tested it manually by running the following commands

```
$ make dist
$ bin/k3sup-darwin app --help
$ bin/k3sup-darwin app info --help
$ bin/k3sup-darwin app info
$ bin/k3sup-darwin app info inlets-operator --help
$ bin/k3sup-darwin app info inlets-operator
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
