### PR TITLE
Adds --set flag to openfaas command

### DIFF
--- a/pkg/cmd/openfaas_app_test.go
+++ b/pkg/cmd/openfaas_app_test.go
@@ -1,6 +1,11 @@
 package cmd
 
-import "testing"
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
 
 func Test_getValuesSuffix_arm64(t *testing.T) {
 	want := "-arm64"
@@ -15,5 +20,100 @@ func Test_getValuesSuffix_aarch64(t *testing.T) {
 	got := getValuesSuffix("aarch64")
 	if want != got {
 		t.Errorf("suffix, want: %s, got: %s", want, got)
+	}
+}
+
+func Test_mergeFlags(t *testing.T) {
+	var (
+		unexpectedErr         = "failed to merge err: %v, existing flags: %v, set overrides: %v"
+		unexpectedMergeErr    = "error merging flags, want: %v, got: %v"
+		inconsistentErrString = "inconsistent error return want: %v, got: %v"
+	)
+	tests := []struct {
+		title          string
+		flags          map[string]string
+		overrides      []string
+		resultExpected map[string]string
+		errExpected    error
+	}{
+		// positive cases:
+		{"Single key with numeric value and no flags",
+			map[string]string{},
+			[]string{"b=1"},
+			map[string]string{"b": "1"},
+			nil,
+		},
+		{"Empty set and no flags, should not fail",
+			map[string]string{},
+			[]string{},
+			map[string]string{},
+			nil,
+		},
+		{"No set key and an existing flag",
+			map[string]string{"a": "1"},
+			[]string{},
+			map[string]string{"a": "1"},
+			nil,
+		},
+		{"Single key with numeric value, override the flag with numeric value",
+			map[string]string{"a": "1"},
+			[]string{"a=2"},
+			map[string]string{"a": "2"},
+			nil,
+		},
+		{"Single key with numeric value and single flag key with numeric value",
+			map[string]string{"a": "1"},
+			[]string{"b=1"},
+			map[string]string{"a": "1", "b": "1"},
+			nil,
+		},
+		{"Single key with numeric value, update existing key and a new key",
+			map[string]string{"a": "1"},
+			[]string{"a=2", "b=1"},
+			map[string]string{"a": "2", "b": "1"},
+			nil,
+		},
+		{"Update all existing flags in the map",
+			map[string]string{"a": "1", "b": "2"},
+			[]string{"a=2", "b=3"},
+			map[string]string{"a": "2", "b": "3"},
+			nil,
+		},
+
+		// check errors
+		{"Incorrect flag format, providing : as a delimiter",
+			map[string]string{"a": "1"},
+			[]string{"a:2"},
+			nil,
+			fmt.Errorf("incorrect format for custom flag `a:2`"),
+		},
+		{"Incorrect flag format, providing space as a delimiter",
+			map[string]string{"a": "1"}, []string{"a 2"},
+			nil,
+			fmt.Errorf("incorrect format for custom flag `a 2`"),
+		},
+		{"Incorrect flag format, providing - as a delimiter",
+			map[string]string{"a": "1"},
+			[]string{"a-2"},
+			nil,
+			fmt.Errorf("incorrect format for custom flag `a-2`"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			err := mergeFlags(test.flags, test.overrides)
+			if err != nil {
+				if test.errExpected == nil {
+					t.Errorf(unexpectedErr, err, test.flags, test.overrides)
+				} else if !strings.EqualFold(err.Error(), test.errExpected.Error()) {
+					t.Errorf(inconsistentErrString, test.errExpected, err)
+				}
+				return
+			}
+			if !reflect.DeepEqual(test.resultExpected, test.flags) {
+				t.Errorf(unexpectedMergeErr, test.resultExpected, test.flags)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a `--set` flag to `k3sup app install openfaas` command. The current implementation contains hard-coded flags that are being passed to `openfaas` installation. This command lets the user add custom flags and override existing hardcoded values for pre-defined flags. All the flags defined as part of the `--set` flag take priority. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Helps users provide custom flags to openfaas install command.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/alexellis/k3sup/issues/140
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- Used k3sup to install a single-node Kubernetes cluster on Ubuntu machine
- Ran the `k3sup app install openfaas --set` command with custom set flags to change the hard-coded values and it worked.

<!--- Include details of your testing environment, and the tests you ran to -->
```
$ ./bin/k3sup-darwin app install openfaas --set gateway.replicas=3 --set basicAuthPlugin.replicas=3 > /dev/null
2020/01/06 11:09:32 User dir established as: /Users/pgogia/.k3sup/
$ kubectl get deploy -n openfaas
SF-US17469-MBP15:k3sup pgogia$ kubectl get deploy -n openfaas
NAME                READY   UP-TO-DATE   AVAILABLE   AGE
nats                1/1     1            1           13m
queue-worker        1/1     1            1           13m
alertmanager        1/1     1            1           13m
prometheus          1/1     1            1           13m
faas-idler          1/1     1            1           13m
gateway             3/3     3            3           13m
basic-auth-plugin   3/3     3            3           13m
```

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.


<!--- Provide a general summary of your changes in the Title above -->
This flag overrides existing flags and allows users to add custom flags.