### PR TITLE
add helm3 flag to inlets operator command

### DIFF
--- a/pkg/cmd/openfaas_app.go
+++ b/pkg/cmd/openfaas_app.go
@@ -16,6 +16,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const helm3Version = "v3.0.1"
+
 func makeInstallOpenFaaS() *cobra.Command {
 	var openfaas = &cobra.Command{
 		Use:          "openfaas",
@@ -82,7 +84,6 @@ func makeInstallOpenFaaS() *cobra.Command {
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
 		if helm3 {
-			helm3Version := "v3.0.1"
 			os.Setenv("HELM_VERSION", helm3Version)
 		}
 


### PR DESCRIPTION
Signed-off-by: Prateek Gogia <prateekgogia42@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
Add helm3 support for inlets-operator

## Description
<!--- Describe your changes in detail -->
Added a new flag to the install inlets-operator command. This new flag is optional, the default behaviour is still using helm2 option. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Partially Fixes #107 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested by install inlets-operator with`--helm3` option and without the flag set i.e using helm2 for installation.

`inlets-operator` components get installed.

```
SF-US17469-MBP15:k3sup pgogia$ ./k3sup app install inlets-operator --token-file=token --helm3
Using kubeconfig: /Users/pgogia/workspace/golang/src/github.com/alexellis/k3sup/kubeconfig
Using helm3
Node architecture: "amd64"
Client: "x86_64", "Darwin"
2020/01/09 10:57:49 User dir established as: /Users/pgogia/.k3sup/
=======================================================================
= inlets-operator has been installed.                                  =
=======================================================================

# The default configuration is for DigitalOcean and your secret is
# stored as "inlets-access-key" in the "default" namespace.

# To get your first Public IP run the following:
kubectl run nginx-1 --image=nginx --port=80 --restart=Always
kubectl expose deployment nginx-1 --port=80 --type=LoadBalancer

# Find your IP in the "EXTERNAL-IP" field, watch for "<pending>" to
# change to an IP

kubectl get svc -w

# When you're done, remove the tunnel by deleting the service
kubectl delete svc/nginx-1

# Find out more at:
# https://github.com/inlets/inlets-operator

Thanks for using k3sup!
```

> Using helm2
```
SF-US17469-MBP15:k3sup pgogia$ ./k3sup app install inlets-operator --token-file=token
Using kubeconfig: /Users/pgogia/workspace/golang/src/github.com/alexellis/k3sup/kubeconfig
Node architecture: "amd64"
Client: "x86_64", "Darwin"
2020/01/09 11:42:01 User dir established as: /Users/pgogia/.k3sup/
=======================================================================
= inlets-operator has been installed.                                  =
=======================================================================

# The default configuration is for DigitalOcean and your secret is
# stored as "inlets-access-key" in the "default" namespace.

# To get your first Public IP run the following:
kubectl run nginx-1 --image=nginx --port=80 --restart=Always
kubectl expose deployment nginx-1 --port=80 --type=LoadBalancer

# Find your IP in the "EXTERNAL-IP" field, watch for "<pending>" to
# change to an IP

kubectl get svc -w

# When you're done, remove the tunnel by deleting the service
kubectl delete svc/nginx-1

# Find out more at:
# https://github.com/inlets/inlets-operator

Thanks for using k3sup!
```
OS: `MacOS`
Version: `10.14.6 (18G2022)`
Golang version: `go1.13.4 darwin/amd64`
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
