### PR TITLE
Add set flag

### DIFF
--- a/cmd/cronconnector_app.go
+++ b/cmd/cronconnector_app.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path"
 
-	"github.com/alexellis/k3sup/pkg/env"
 	"github.com/alexellis/k3sup/pkg/config"
+	"github.com/alexellis/k3sup/pkg/env"
 	"github.com/spf13/cobra"
 )
 
@@ -22,6 +22,9 @@ func makeInstallCronConnector() *cobra.Command {
 
 	command.Flags().StringP("namespace", "n", "openfaas", "The namespace used for installation")
 	command.Flags().Bool("update-repo", true, "Update the helm repo")
+
+	command.Flags().StringArray("set", []string{},
+		"Use custom flags or override existing flags \n(example --set key=value)")
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
@@ -77,6 +80,15 @@ func makeInstallCronConnector() *cobra.Command {
 		}
 
 		overrides := map[string]string{}
+
+		customFlags, err := command.Flags().GetStringArray("set")
+		if err != nil {
+			return fmt.Errorf("error with --set usage: %s", err)
+		}
+
+		if err := mergeFlags(overrides, customFlags); err != nil {
+			return err
+		}
 
 		arch := getNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)

--- a/cmd/kafkaconnector_app.go
+++ b/cmd/kafkaconnector_app.go
@@ -25,6 +25,8 @@ func makeInstallKafkaConnector() *cobra.Command {
 	command.Flags().Bool("update-repo", true, "Update the helm repo")
 	command.Flags().StringP("topics", "t", "faas-request", "The topics for the connector to bind to")
 	command.Flags().String("broker-host", "kafka", "The host for the Kafka broker")
+	command.Flags().StringArray("set", []string{},
+		"Use custom flags or override existing flags \n(example --set key=value)")
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
@@ -92,6 +94,15 @@ func makeInstallKafkaConnector() *cobra.Command {
 		overrides := map[string]string{
 			"topics":      topicsVal,
 			"broker_host": brokerHostVal,
+		}
+
+		customFlags, err := command.Flags().GetStringArray("set")
+		if err != nil {
+			return fmt.Errorf("error with --set usage: %s", err)
+		}
+
+		if err := mergeFlags(overrides, customFlags); err != nil {
+			return err
 		}
 
 		arch := getNodeArchitecture()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add --set flag option to commands

## Description
Adds --set flag option to following commands:
 - cron-connector
 - kafka-connector
 - minio
 - postgers

<!--- Describe your changes in detail -->
`--set` flag option helps with overriding existing hard-coded flags or add custom flags for installing an app.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?

> kafkaconnector output -
```
SF-US17469-MBP15:k3sup pgogia$ ./k3sup app install kafka-connector --help
Install kafka-connector for OpenFaaS

Usage:
  k3sup app install kafka-connector [flags]

Examples:
  k3sup app install kafka-connector

Flags:
      --broker-host string   The host for the Kafka broker (default "kafka")
  -h, --help                 help for kafka-connector
  -n, --namespace string     The namespace used for installation (default "openfaas")
      --set stringArray      Use custom flags or override existing flags
                             (example --set key=value)
  -t, --topics string        The topics for the connector to bind to (default "faas-request")
      --update-repo          Update the helm repo (default true)

Global Flags:
      --kubeconfig string   Local path for your kubeconfig file (default "kubeconfig")
SF-US17469-MBP15:k3sup pgogia$
```

> cron-connector output -

```
SF-US17469-MBP15:k3sup pgogia$ ./k3sup app install cron-connector --help
Install cron-connector for OpenFaaS

Usage:
  k3sup app install cron-connector [flags]

Examples:
  k3sup app install cron-connector

Flags:
  -h, --help               help for cron-connector
  -n, --namespace string   The namespace used for installation (default "openfaas")
      --set stringArray    Use custom flags or override existing flags
                           (example --set key=value)
      --update-repo        Update the helm repo (default true)

Global Flags:
      --kubeconfig string   Local path for your kubeconfig file (default "kubeconfig")
```

> minio output -

```
SF-US17469-MBP15:k3sup pgogia$ ./k3sup app install minio --help
Install minio

Usage:
  k3sup app install minio [flags]

Examples:
  k3sup app install minio

Flags:
      --access-key string   Provide an access key to override the pre-generated value
      --distributed         Deploy Minio in Distributed Mode
  -h, --help                help for minio
      --namespace string    Kubernetes namespace for the application (default "default")
      --persistence         Enable persistence
      --secret-key string   Provide a secret key to override the pre-generated value
      --set stringArray     Use custom flags or override existing flags
                            (example --set persistence.enabled=true)
      --update-repo         Update the helm repo (default true)

Global Flags:
      --kubeconfig string   Local path for your kubeconfig file (default "kubeconfig")
SF-US17469-MBP15:k3sup pgogia$
```

> postgresql output -

```
SF-US17469-MBP15:k3sup pgogia$ ./k3sup app install postgresql --help
Install postgresql

Usage:
  k3sup app install postgresql [flags]

Examples:
  k3sup app install postgresql

Flags:
  -h, --help               help for postgresql
      --namespace string   Kubernetes namespace for the application (default "default")
      --persistence        Enable persistence
      --set stringArray    Use custom flags or override existing flags
                           (example --set persistence.enabled=true)
      --update-repo        Update the helm repo (default true)

Global Flags:
      --kubeconfig string   Local path for your kubeconfig file (default "kubeconfig")
SF-US17469-MBP15:k3sup pgogia$

```


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
