### PR TITLE
Move to apps to their own package

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/alexellis/k3sup/cmd/apps"
 	"github.com/spf13/cobra"
 )
 
@@ -65,9 +66,9 @@ func MakeApps() *cobra.Command {
 
 		switch appName {
 		case "inlets-operator":
-			fmt.Println(inletsOperatorInfoMsg)
+			fmt.Println(apps.InletsOperatorInfoMsg)
 		case "openfaas":
-			fmt.Println(openfaasInfoMsg)
+			fmt.Println(apps.OpenFaaSInfoMsg)
 		default:
 			return fmt.Errorf("no info or no app available for %s", appName)
 		}
@@ -76,21 +77,21 @@ func MakeApps() *cobra.Command {
 	}
 
 	command.AddCommand(install)
-	install.AddCommand(makeInstallOpenFaaS())
-	install.AddCommand(makeInstallMetricsServer())
-	install.AddCommand(makeInstallInletsOperator())
-	install.AddCommand(makeInstallCertManager())
-	install.AddCommand(makeInstallOpenFaaSIngress())
-	install.AddCommand(makeInstallNginx())
-	install.AddCommand(makeInstallChart())
-	install.AddCommand(makeInstallTiller())
-	install.AddCommand(makeInstallLinkerd())
-	install.AddCommand(makeInstallCronConnector())
-	install.AddCommand(makeInstallKafkaConnector())
-	install.AddCommand(makeInstallMinio())
-	install.AddCommand(makeInstallPostgresql())
-	install.AddCommand(makeInstallKubernetesDashboard())
-	install.AddCommand(makeInstallIstio())
+	install.AddCommand(apps.MakeInstallOpenFaaS())
+	install.AddCommand(apps.MakeInstallMetricsServer())
+	install.AddCommand(apps.MakeInstallInletsOperator())
+	install.AddCommand(apps.MakeInstallCertManager())
+	install.AddCommand(apps.MakeInstallOpenFaaSIngress())
+	install.AddCommand(apps.MakeInstallNginx())
+	install.AddCommand(apps.MakeInstallChart())
+	install.AddCommand(apps.MakeInstallTiller())
+	install.AddCommand(apps.MakeInstallLinkerd())
+	install.AddCommand(apps.MakeInstallCronConnector())
+	install.AddCommand(apps.MakeInstallKafkaConnector())
+	install.AddCommand(apps.MakeInstallMinio())
+	install.AddCommand(apps.MakeInstallPostgresql())
+	install.AddCommand(apps.MakeInstallKubernetesDashboard())
+	install.AddCommand(apps.MakeInstallIstio())
 
 	command.AddCommand(info)
 

--- a/cmd/apps/certmanager_app.go
+++ b/cmd/apps/certmanager_app.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"fmt"
@@ -6,13 +6,14 @@ import (
 	"os"
 	"path"
 
+	"github.com/alexellis/k3sup/pkg"
 	"github.com/alexellis/k3sup/pkg/config"
 	"github.com/alexellis/k3sup/pkg/env"
 
 	"github.com/spf13/cobra"
 )
 
-func makeInstallCertManager() *cobra.Command {
+func MakeInstallCertManager() *cobra.Command {
 	var certManager = &cobra.Command{
 		Use:          "cert-manager",
 		Short:        "Install cert-manager",
@@ -126,7 +127,7 @@ func makeInstallCertManager() *cobra.Command {
 
 kubectl logs -n cert-manager deploy/cert-manager -f
 
-` + thanksForUsing)
+` + pkg.ThanksForUsing)
 
 		return nil
 	}

--- a/cmd/apps/chart_app.go
+++ b/cmd/apps/chart_app.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"fmt"
@@ -7,12 +7,14 @@ import (
 	"path"
 	"strings"
 
+	"github.com/alexellis/k3sup/pkg"
+
 	"github.com/alexellis/k3sup/pkg/config"
 	"github.com/alexellis/k3sup/pkg/env"
 	"github.com/spf13/cobra"
 )
 
-func makeInstallChart() *cobra.Command {
+func MakeInstallChart() *cobra.Command {
 	var chartCmd = &cobra.Command{
 		Use:   "chart",
 		Short: "Install the specified helm chart",
@@ -143,7 +145,7 @@ before using the generic helm chart installer command.`,
 chart ` + chartRepoName + ` installed.
 =======================================================================
 		
-` + thanksForUsing)
+` + pkg.ThanksForUsing)
 
 		return nil
 	}

--- a/cmd/apps/cronconnector_app.go
+++ b/cmd/apps/cronconnector_app.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"fmt"
@@ -6,12 +6,14 @@ import (
 	"os"
 	"path"
 
+	"github.com/alexellis/k3sup/pkg"
+
 	"github.com/alexellis/k3sup/pkg/config"
 	"github.com/alexellis/k3sup/pkg/env"
 	"github.com/spf13/cobra"
 )
 
-func makeInstallCronConnector() *cobra.Command {
+func MakeInstallCronConnector() *cobra.Command {
 	var command = &cobra.Command{
 		Use:          "cron-connector",
 		Short:        "Install cron-connector for OpenFaaS",
@@ -133,7 +135,7 @@ kubectl logs deploy/cron-connector -n openfaas -f
 
 # https://github.com/openfaas-incubator/cron-connector/
 
-` + thanksForUsing)
+` + pkg.ThanksForUsing)
 
 		return nil
 	}

--- a/cmd/apps/inletsoperator_app.go
+++ b/cmd/apps/inletsoperator_app.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"fmt"
@@ -7,12 +7,14 @@ import (
 	"path"
 	"strings"
 
+	"github.com/alexellis/k3sup/pkg"
+
 	"github.com/alexellis/k3sup/pkg/config"
 	"github.com/alexellis/k3sup/pkg/env"
 	"github.com/spf13/cobra"
 )
 
-func makeInstallInletsOperator() *cobra.Command {
+func MakeInstallInletsOperator() *cobra.Command {
 	var inletsOperator = &cobra.Command{
 		Use:          "inlets-operator",
 		Short:        "Install inlets-operator",
@@ -194,7 +196,7 @@ func getOverridesWithPlatform(command *cobra.Command) map[string]string {
 	return overrides
 }
 
-const inletsOperatorInfoMsg = `# The default configuration is for DigitalOcean and your secret is
+const InletsOperatorInfoMsg = `# The default configuration is for DigitalOcean and your secret is
 # stored as "inlets-access-key" in the "default" namespace.
 
 # To get your first Public IP run the following:
@@ -215,4 +217,4 @@ kubectl delete svc/nginx-1
 const inletsOperatorPostInstallMsg = `=======================================================================
 = inlets-operator has been installed.                                  =
 =======================================================================` +
-	"\n\n" + inletsOperatorInfoMsg + "\n\n" + thanksForUsing
+	"\n\n" + InletsOperatorInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/apps/istio_app.go
+++ b/cmd/apps/istio_app.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"fmt"
@@ -7,13 +7,14 @@ import (
 	"os"
 	"path"
 
+	"github.com/alexellis/k3sup/pkg"
 	"github.com/alexellis/k3sup/pkg/config"
 	"github.com/alexellis/k3sup/pkg/env"
 
 	"github.com/spf13/cobra"
 )
 
-func makeInstallIstio() *cobra.Command {
+func MakeInstallIstio() *cobra.Command {
 	var istio = &cobra.Command{
 		Use:          "istio",
 		Short:        "Install istio",
@@ -147,7 +148,7 @@ const istioInfoMsg = `# Find out more at:
 const istioPostInstallMsg = `=======================================================================
 = Istio has been installed.                                        =
 =======================================================================` +
-	"\n\n" + istioInfoMsg + "\n\n" + thanksForUsing
+	"\n\n" + istioInfoMsg + "\n\n" + pkg.ThanksForUsing
 
 func writeIstioValues() (string, error) {
 	out := `#

--- a/cmd/apps/kafkaconnector_app.go
+++ b/cmd/apps/kafkaconnector_app.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"fmt"
@@ -6,13 +6,13 @@ import (
 	"os"
 	"path"
 
+	"github.com/alexellis/k3sup/pkg"
 	"github.com/alexellis/k3sup/pkg/config"
-
 	"github.com/alexellis/k3sup/pkg/env"
 	"github.com/spf13/cobra"
 )
 
-func makeInstallKafkaConnector() *cobra.Command {
+func MakeInstallKafkaConnector() *cobra.Command {
 	var command = &cobra.Command{
 		Use:          "kafka-connector",
 		Short:        "Install kafka-connector for OpenFaaS",
@@ -142,7 +142,7 @@ kubectl logs deploy/kafka-connector -n openfaas -f
 
 # https://github.com/openfaas-incubator/kafka-connector/
 
-` + thanksForUsing)
+` + pkg.ThanksForUsing)
 
 		return nil
 	}

--- a/cmd/apps/kubernetes_dashboard_app.go
+++ b/cmd/apps/kubernetes_dashboard_app.go
@@ -1,11 +1,14 @@
-package cmd
+package apps
 
 import (
 	"fmt"
+
+	"github.com/alexellis/k3sup/pkg"
+
 	"github.com/spf13/cobra"
 )
 
-func makeInstallKubernetesDashboard() *cobra.Command {
+func MakeInstallKubernetesDashboard() *cobra.Command {
 	var kubeDashboard = &cobra.Command{
 		Use:          "kubernetes-dashboard",
 		Short:        "Install kubernetes-dashboard",
@@ -71,7 +74,7 @@ kubectl -n kubernetes-dashboard describe secret $(kubectl -n kubernetes-dashboar
 # Once Proxying you can navigate to the below
 http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/login
 
-` + thanksForUsing)
+` + pkg.ThanksForUsing)
 
 		return nil
 	}

--- a/cmd/apps/kubernetes_exec.go
+++ b/cmd/apps/kubernetes_exec.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"fmt"

--- a/cmd/apps/linkerd_app.go
+++ b/cmd/apps/linkerd_app.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"bufio"
@@ -12,13 +12,15 @@ import (
 	"path"
 	"strings"
 
+	"github.com/alexellis/k3sup/pkg"
+
 	execute "github.com/alexellis/go-execute/pkg/v1"
 	"github.com/alexellis/k3sup/pkg/config"
 	"github.com/alexellis/k3sup/pkg/env"
 	"github.com/spf13/cobra"
 )
 
-func makeInstallLinkerd() *cobra.Command {
+func MakeInstallLinkerd() *cobra.Command {
 	var linkerd = &cobra.Command{
 		Use:          "linkerd",
 		Short:        "Install linkerd",
@@ -98,7 +100,7 @@ curl -sL https://run.linkerd.io/install | sh
 export PATH=$PATH:` + path.Join(userPath, "bin/") + `
 linkerd --help
 
-` + thanksForUsing)
+` + pkg.ThanksForUsing)
 		return nil
 	}
 

--- a/cmd/apps/metricsserver_app.go
+++ b/cmd/apps/metricsserver_app.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"fmt"
@@ -6,13 +6,13 @@ import (
 	"os"
 	"path"
 
+	"github.com/alexellis/k3sup/pkg"
 	"github.com/alexellis/k3sup/pkg/config"
-
-	"github.com/spf13/cobra"
 	"github.com/alexellis/k3sup/pkg/env"
+	"github.com/spf13/cobra"
 )
 
-func makeInstallMetricsServer() *cobra.Command {
+func MakeInstallMetricsServer() *cobra.Command {
 	var metricsServer = &cobra.Command{
 		Use:          "metrics-server",
 		Short:        "Install metrics-server",
@@ -111,7 +111,7 @@ kubectl top node
 # Find out more at:
 # https://github.com/helm/charts/tree/master/stable/metrics-server
 
-` + thanksForUsing)
+` + pkg.ThanksForUsing)
 
 		return nil
 	}

--- a/cmd/apps/minio_app.go
+++ b/cmd/apps/minio_app.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"fmt"
@@ -8,13 +8,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/alexellis/k3sup/pkg"
 	"github.com/alexellis/k3sup/pkg/config"
 	"github.com/alexellis/k3sup/pkg/env"
 	"github.com/sethvargo/go-password/password"
 	"github.com/spf13/cobra"
 )
 
-func makeInstallMinio() *cobra.Command {
+func MakeInstallMinio() *cobra.Command {
 	var minio = &cobra.Command{
 		Use:          "minio",
 		Short:        "Install minio",
@@ -158,7 +159,7 @@ mc ls minio
 
 # Find out more at: https://min.io
 
-` + thanksForUsing)
+` + pkg.ThanksForUsing)
 		return nil
 	}
 

--- a/cmd/apps/nginx_app.go
+++ b/cmd/apps/nginx_app.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"fmt"
@@ -6,13 +6,13 @@ import (
 	"os"
 	"path"
 
-	"github.com/alexellis/k3sup/pkg/env"
+	"github.com/alexellis/k3sup/pkg"
 	"github.com/alexellis/k3sup/pkg/config"
-
+	"github.com/alexellis/k3sup/pkg/env"
 	"github.com/spf13/cobra"
 )
 
-func makeInstallNginx() *cobra.Command {
+func MakeInstallNginx() *cobra.Command {
 	var nginx = &cobra.Command{
 		Use:          "nginx-ingress",
 		Short:        "Install nginx-ingress",
@@ -137,7 +137,7 @@ kubectl get svc nginx-ingress-controller
 # Find out more at:
 # https://github.com/helm/charts/tree/master/stable/nginx-ingress
 
-` + thanksForUsing)
+` + pkg.ThanksForUsing)
 
 		return nil
 	}

--- a/cmd/apps/openfaas_app.go
+++ b/cmd/apps/openfaas_app.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"fmt"
@@ -8,17 +8,17 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/alexellis/k3sup/pkg"
 	"github.com/sethvargo/go-password/password"
 
 	"github.com/alexellis/k3sup/pkg/config"
 	"github.com/alexellis/k3sup/pkg/env"
-
 	"github.com/spf13/cobra"
 )
 
 const helm3Version = "v3.0.1"
 
-func makeInstallOpenFaaS() *cobra.Command {
+func MakeInstallOpenFaaS() *cobra.Command {
 	var openfaas = &cobra.Command{
 		Use:          "openfaas",
 		Short:        "Install openfaas",
@@ -269,7 +269,7 @@ func mergeFlags(existingMap map[string]string, setOverrides []string) error {
 	return nil
 }
 
-const openfaasInfoMsg = `# Get the faas-cli
+const OpenFaaSInfoMsg = `# Get the faas-cli
 curl -SLsf https://cli.openfaas.com | sudo sh
 
 # Forward the gateway to your machine
@@ -296,4 +296,4 @@ faas-cli store deploy figlet \
 const openfaasPostInstallMsg = `=======================================================================
 = OpenFaaS has been installed.                                        =
 =======================================================================` +
-	"\n\n" + openfaasInfoMsg + "\n\n" + thanksForUsing
+	"\n\n" + OpenFaaSInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/apps/openfaas_app_test.go
+++ b/cmd/apps/openfaas_app_test.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"fmt"

--- a/cmd/apps/openfaas_ingress_app.go
+++ b/cmd/apps/openfaas_ingress_app.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"bytes"
@@ -11,6 +11,8 @@ import (
 
 	"text/template"
 
+	"github.com/alexellis/k3sup/pkg"
+
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +22,7 @@ type InputData struct {
 	IngressClass     string
 }
 
-func makeInstallOpenFaaSIngress() *cobra.Command {
+func MakeInstallOpenFaaSIngress() *cobra.Command {
 	var openfaasIngress = &cobra.Command{
 		Use:          "openfaas-ingress",
 		Short:        "Install openfaas ingress with TLS",
@@ -107,7 +109,7 @@ kubectl describe -n openfaas Certificate openfaas-gateway
 # It may take a while to be issued by LetsEncrypt, in the meantime a 
 # self-signed cert will be installed
 
-` + thanksForUsing)
+` + pkg.ThanksForUsing)
 
 		return nil
 	}

--- a/cmd/apps/openfaas_ingress_app_test.go
+++ b/cmd/apps/openfaas_ingress_app_test.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"io/ioutil"

--- a/cmd/apps/postgres_app.go
+++ b/cmd/apps/postgres_app.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"fmt"
@@ -8,12 +8,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/alexellis/k3sup/pkg"
 	"github.com/alexellis/k3sup/pkg/config"
 	"github.com/alexellis/k3sup/pkg/env"
 	"github.com/spf13/cobra"
 )
 
-func makeInstallPostgresql() *cobra.Command {
+func MakeInstallPostgresql() *cobra.Command {
 	var postgresql = &cobra.Command{
 		Use:          "postgresql",
 		Short:        "Install postgresql",
@@ -138,7 +139,7 @@ To connect to your database from outside the cluster execute the following comma
 
 # Find out more at: https://github.com/helm/charts/tree/master/stable/postgresql
 
-` + thanksForUsing)
+` + pkg.ThanksForUsing)
 		return nil
 	}
 

--- a/cmd/apps/tiller_app.go
+++ b/cmd/apps/tiller_app.go
@@ -1,4 +1,4 @@
-package cmd
+package apps
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 	"path"
 
 	execute "github.com/alexellis/go-execute/pkg/v1"
+	"github.com/alexellis/k3sup/pkg"
 
 	"github.com/alexellis/k3sup/pkg/config"
 	"github.com/alexellis/k3sup/pkg/env"
@@ -14,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func makeInstallTiller() *cobra.Command {
+func MakeInstallTiller() *cobra.Command {
 	var tiller = &cobra.Command{
 		Use:          "tiller",
 		Short:        "Install tiller",
@@ -95,7 +96,7 @@ tiller has been installed
 
 ` + helmBinary + `
 
-` + thanksForUsing)
+` + pkg.ThanksForUsing)
 
 		return nil
 	}

--- a/cmd/apps/untar.go
+++ b/cmd/apps/untar.go
@@ -5,7 +5,7 @@
 // Edited on 2019-10-11 to remove support for nested folders when un-taring
 // so that all files are placed in the same target directory
 
-package cmd
+package apps
 
 import (
 	"archive/tar"

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -30,5 +30,3 @@ curl -SLfs https://get.k3sup.dev | sh
 # Or download from GitHub: https://github.com/alexellis/k3sup/releases
 
 Thanks for using k3sup!`
-
-const thanksForUsing = `Thanks for using k3sup!`

--- a/pkg/thanks.go
+++ b/pkg/thanks.go
@@ -1,0 +1,3 @@
+package pkg
+
+const ThanksForUsing = `Thanks for using k3sup!`


### PR DESCRIPTION
Move to apps to their own package

This patch moves apps into their own package, there is more that
can be done to extract code, for instance untar, could move to
pkg/ instead of sitting in cmd/. There may be other examples
too. Tested by installing OpenFaaS with helm3 to Civo's k3s
service.

Closes: #158

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>
