### PR TITLE
Upgrade to k3s v1.17.2+k3s1

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 // K3sVersion default version
-const K3sVersion = "v1.0.1"
+const K3sVersion = "v1.17.2+k3s1"
 
 func InitUserDir() (string, error) {
 	home := os.Getenv("HOME")


### PR DESCRIPTION
Signed-off-by: Mario Vejlupek <mario@vejlupek.cz>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgrade to v1.17.2+k3s1 of k3s

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
  closes #167


## How Has This Been Tested?

```
k3sup on  master [!] via 🐹 v1.13.6 took 5s 
➜ make build
go build
go: downloading github.com/spf13/cobra v0.0.5
go: downloading github.com/morikuni/aec v1.0.0
go: downloading github.com/mitchellh/go-homedir v1.1.0
go: downloading golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
go: downloading github.com/pkg/errors v0.8.1
go: downloading github.com/alexellis/go-execute v0.0.0-20191207085904-961405ea7544
go: downloading github.com/sethvargo/go-password v0.1.2
go: extracting github.com/pkg/errors v0.8.1
go: extracting github.com/mitchellh/go-homedir v1.1.0
go: extracting github.com/alexellis/go-execute v0.0.0-20191207085904-961405ea7544
go: extracting golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
go: extracting github.com/spf13/cobra v0.0.5
go: extracting github.com/morikuni/aec v1.0.0
go: extracting github.com/sethvargo/go-password v0.1.2
go: downloading github.com/spf13/pflag v1.0.5
go: downloading golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456
go: extracting github.com/spf13/pflag v1.0.5
go: extracting golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456
go: finding github.com/mitchellh/go-homedir v1.1.0
go: finding github.com/morikuni/aec v1.0.0
go: finding github.com/spf13/cobra v0.0.5
go: finding github.com/pkg/errors v0.8.1
go: finding golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
go: finding github.com/alexellis/go-execute v0.0.0-20191207085904-961405ea7544
go: finding github.com/sethvargo/go-password v0.1.2
go: finding github.com/spf13/pflag v1.0.5
go: finding golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456

k3sup on  master [!] via 🐹 v1.13.6 
➜ /Users/Mario.Vejlupek/go/src/github.com/alexellis/k3sup/k3sup install --ip 10.236.64.56 --cluster
Running: k3sup install
Public IP: 10.236.64.56
ssh -i /Users/Mario.Vejlupek/.ssh/id_rsa -p 22 root@10.236.64.56
ssh: curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --cluster-init --tls-san 10.236.64.56 ' INSTALL_K3S_VERSION='v1.17.2+k3s1' sh -

[INFO]  Using v1.17.2+k3s1 as release
[INFO]  Downloading hash https://github.com/rancher/k3s/releases/download/v1.17.2+k3s1/sha256sum-arm.txt
[INFO]  Downloading binary https://github.com/rancher/k3s/releases/download/v1.17.2+k3s1/k3s-armhf
[INFO]  Verifying binary download
[INFO]  Installing k3s to /usr/local/bin/k3s
[INFO]  Skipping /usr/local/bin/kubectl symlink to k3s, already exists
[INFO]  Skipping /usr/local/bin/crictl symlink to k3s, already exists
[INFO]  Skipping /usr/local/bin/ctr symlink to k3s, command exists in PATH at /usr/bin/ctr
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.
[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
[INFO]  systemd: Enabling k3s unit
[INFO]  systemd: Starting k3s
Result: [INFO]  Using v1.17.2+k3s1 as release
[INFO]  Downloading hash https://github.com/rancher/k3s/releases/download/v1.17.2+k3s1/sha256sum-arm.txt
[INFO]  Downloading binary https://github.com/rancher/k3s/releases/download/v1.17.2+k3s1/k3s-armhf
[INFO]  Verifying binary download
[INFO]  Installing k3s to /usr/local/bin/k3s
[INFO]  Skipping /usr/local/bin/kubectl symlink to k3s, already exists
[INFO]  Skipping /usr/local/bin/crictl symlink to k3s, already exists
[INFO]  Skipping /usr/local/bin/ctr symlink to k3s, command exists in PATH at /usr/bin/ctr
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
[INFO]  systemd: Enabling k3s unit
[INFO]  systemd: Starting k3s
 Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.

ssh: sudo cat /etc/rancher/k3s/k3s.yaml

apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJWakNCL3FBREFnRUNBZ0VBTUFvR0NDcUdTTTQ5QkFNQ01DTXhJVEFmQmdOVkJBTU1HR3N6Y3kxelpYSjIKWlhJdFkyRkFNVFU0TURFMU9ESXlOVEFlRncweU1EQXhNamN5TURVd01qVmFGdzB6TURBeE1qUXlNRFV3TWpWYQpNQ014SVRBZkJnTlZCQU1NR0dzemN5MXpaWEoyWlhJdFkyRkFNVFU0TURFMU9ESXlOVEJaTUJNR0J5cUdTTTQ5CkFnRUdDQ3FHU000OUF3RUhBMElBQkpSN29LejhjeG1IejJYb0owd0lvaDRkYnltR0wxZ2hoVHFjaW1QNmRYWGEKTlhNNDZRVElDM2dXZFQvRWhhYnkvRTNWZStXcDhleC95c0E1WTBadU9WS2pJekFoTUE0R0ExVWREd0VCL3dRRQpBd0lDcERBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUFvR0NDcUdTTTQ5QkFNQ0EwY0FNRVFDSUg1ZXJGRkpZY3cwClovc2JNclJJYXJ3OUtQcVpTdWJGVGtnRWNjZkRlMk5WQWlBejJHSEdGRWtFcDl2ckJFUjFtdlEvQmg4TWJGQmQKOUcwNXJuYVBDWjZha2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
    server: https://127.0.0.1:6443
  name: default
contexts:
- context:
    cluster: default
    user: default
  name: default
current-context: default
kind: Config
preferences: {}
users:
- name: default
  user:
    password: 965079229e2afeb4fdd9e51560aee299
    username: admin
Result: apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJWakNCL3FBREFnRUNBZ0VBTUFvR0NDcUdTTTQ5QkFNQ01DTXhJVEFmQmdOVkJBTU1HR3N6Y3kxelpYSjIKWlhJdFkyRkFNVFU0TURFMU9ESXlOVEFlRncweU1EQXhNamN5TURVd01qVmFGdzB6TURBeE1qUXlNRFV3TWpWYQpNQ014SVRBZkJnTlZCQU1NR0dzemN5MXpaWEoyWlhJdFkyRkFNVFU0TURFMU9ESXlOVEJaTUJNR0J5cUdTTTQ5CkFnRUdDQ3FHU000OUF3RUhBMElBQkpSN29LejhjeG1IejJYb0owd0lvaDRkYnltR0wxZ2hoVHFjaW1QNmRYWGEKTlhNNDZRVElDM2dXZFQvRWhhYnkvRTNWZStXcDhleC95c0E1WTBadU9WS2pJekFoTUE0R0ExVWREd0VCL3dRRQpBd0lDcERBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUFvR0NDcUdTTTQ5QkFNQ0EwY0FNRVFDSUg1ZXJGRkpZY3cwClovc2JNclJJYXJ3OUtQcVpTdWJGVGtnRWNjZkRlMk5WQWlBejJHSEdGRWtFcDl2ckJFUjFtdlEvQmg4TWJGQmQKOUcwNXJuYVBDWjZha2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
    server: https://127.0.0.1:6443
  name: default
contexts:
- context:
    cluster: default
    user: default
  name: default
current-context: default
kind: Config
preferences: {}
users:
- name: default
  user:
    password: 965079229e2afeb4fdd9e51560aee299
    username: admin
 
Saving file to: /Users/Mario.Vejlupek/go/src/github.com/alexellis/k3sup/kubeconfig

# Test your cluster with:
export KUBECONFIG=/Users/Mario.Vejlupek/go/src/github.com/alexellis/k3sup/kubeconfig
kubectl get node -o wide

k3sup on  master [!] via 🐹 v1.13.6 took 43s 
➜ export KUBECONFIG=/Users/Mario.Vejlupek/go/src/github.com/alexellis/k3sup/kubeconfig
kubectl get node -o wide
NAME               STATUS     ROLES    AGE   VERSION        INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION   CONTAINER-RUNTIME
100000007368d69d   NotReady   master   16m   v1.17.2+k3s1   10.236.64.56   <none>        Raspbian GNU/Linux 10 (buster)   4.19.75-v7l+     containerd://1.3.3-k3s1
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
