### PR TITLE
Make inlets-operator not fail on existing secret

### DIFF
--- a/cmd/apps/inletsoperator_app.go
+++ b/cmd/apps/inletsoperator_app.go
@@ -116,11 +116,11 @@ func MakeInstallInletsOperator() *cobra.Command {
 			"inlets-access-key",
 			"--from-file", "inlets-access-key="+secretFileName)
 
-		if len(res.Stderr) > 0 {
+		if len(res.Stderr) > 0 && strings.Contains(res.Stderr, "AlreadyExists") {
+			fmt.Println("[Warning] secret inlets-access-key already exists and will be used.")
+		} else if len(res.Stderr) > 0 {
 			return fmt.Errorf("Error from kubectl\n%q", res.Stderr)
-		}
-
-		if err != nil {
+		} else if err != nil {
 			return err
 		}
 


### PR DESCRIPTION
In order for the inlets-operator app to not fail on re-runs
it is necessary for the command to be resilient to the
inlets-access-key secret already being present in cluster.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Currently, running `k3sup app install inlets-operator` after it has already been run once will fail due to the presence of the `inlets-access-key` secret already being present. This change updates behavior to log when the secret is already present, but to continue execution using the existing secret.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes #172 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Running installation for the first time on a k3s cluster set up using k3sup:
```
Using kubeconfig: /home/dan/code/github.com/alexellis/k3sup/kubeconfig                                                                                                                                      
amd64Node architecture: "amd64"                                                                                                                                                                             
x86_64                                                                                                                                                                                                      
Linux                                                                                                                                                                                                       
Client: "x86_64", "Linux"                                                                                                                                                                                   
2020/01/29 10:51:37 User dir established as: /home/dan/.k3sup/                                                                                                                                              
"inlets" has been added to your repositories                                                                                                                                                                
Hang tight while we grab the latest from your chart repositories...                                                                                                                                         
...Skip local chart repository                                                                                                                                                                              
...Successfully got an update from the "inlets" chart repository                                                                                                                                            
...Successfully got an update from the "crossplane-alpha" chart repository                                                                                                                                  
...Successfully got an update from the "stable" chart repository                                                                                                                                            
Update Complete.                                                                                                                                                                                            
...
```

Running installation for a second time on same k3s cluster:
```
Using kubeconfig: /home/dan/code/github.com/alexellis/k3sup/kubeconfig                                                                                                                                      
amd64Node architecture: "amd64"                                                                                                                                                                             
x86_64                                                                                                                                                                                                      
Linux                                                                                                                                                                                                       
Client: "x86_64", "Linux"                                                                                                                                                                                   
2020/01/29 10:51:37 User dir established as: /home/dan/.k3sup/                                                                                                                                              
"inlets" has been added to your repositories                                                                                                                                                                
Hang tight while we grab the latest from your chart repositories...                                                                                                                                         
...Skip local chart repository                                                                                                                                                                              
...Successfully got an update from the "inlets" chart repository                                                                                                                                            
...Successfully got an update from the "crossplane-alpha" chart repository                                                                                                                                  
...Successfully got an update from the "stable" chart repository                                                                                                                                            
Update Complete.                                                                                                                                                                                            
Error from server (AlreadyExists): secrets "inlets-access-key" already exists                                                                                                                               
[Warning] secret inlets-access-key already exists and will be used.
...
```

*Note: we still get the `Error from server (AlreadyExists): secrets "inlets-access-key` already exists` printed in output because of https://github.com/alexellis/k3sup/blob/5ce8d6a206dce1abb6747e688bbe72fb9df67fb2/cmd/apps/kubernetes_exec.go#L240. This could be changed in the future if it is desirable not to always show the kubectl output immediately.*

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
