### PR TITLE
Update Kubernetes Dashboard to 2.0.0-rc2 and fixes automatic admin account

### DIFF
--- a/cmd/apps/kubernetes_dashboard_app.go
+++ b/cmd/apps/kubernetes_dashboard_app.go
@@ -30,22 +30,27 @@ func MakeInstallKubernetesDashboard() *cobra.Command {
 		fmt.Printf("Node architecture: %q\n", arch)
 
 		_, err := kubectlTask("apply", "-f",
-			"https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta6/aio/deploy/recommended.yaml")
-		if err != nil {
-			return err
-		}
-		_, err = kubectlTask("apply", "-",
-			`apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: admin-user
-  namespace: kubernetes-dashboard`)
+			"https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-rc2/aio/deploy/recommended.yaml")
 		if err != nil {
 			return err
 		}
 
-		_, err = kubectlTask("apply", "-",
-			`apiVersion: rbac.authorization.k8s.io/v1
+		fmt.Println(`=======================================================================
+= Kubernetes Dashboard has been installed.                                        =
+=======================================================================
+
+#To create the Service Account and the ClusterRoleBinding
+# @See https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/creating-sample-user.md#creating-sample-user
+
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: admin-user
@@ -56,14 +61,9 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: admin-user
-  namespace: kubernetes-dashboard`)
-		if err != nil {
-			return err
-		}
-
-		fmt.Println(`=======================================================================
-= Kubernetes Dashboard has been installed.                                        =
-=======================================================================
+  namespace: kubernetes-dashboard
+---
+EOF
 
 #To forward the dashboard to your local machine 
 kubectl proxy

--- a/cmd/apps/kubernetes_dashboard_app.go
+++ b/cmd/apps/kubernetes_dashboard_app.go
@@ -69,7 +69,7 @@ EOF
 kubectl proxy
 
 #To get your Token for logging in
-kubectl -n kubernetes-dashboard describe secret $(kubectl -n kubernetes-dashboard get secret | grep default-token | awk '{print $1}')
+kubectl -n kubernetes-dashboard describe secret $(kubectl -n kubernetes-dashboard get secret | grep admin-user-token | awk '{print $1}')
 
 # Once Proxying you can navigate to the below
 http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/login


### PR DESCRIPTION
Update Kubernetes Dashboard to the latest version 2.0.0-rc2 and fixes account admin creation (currently failing), making this optional .

## Description

* Updated kubernetes-dashboard URL to the latest version 2.0.0-rc2 (from beta-6)
* hints the user how to create admin user, not creating it directly. According to https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/creating-sample-user.md#creating-sample-user the admin user "is for educational purposes only"


## Motivation and Context

- [x] I have raised an issue to propose this change  
https://github.com/alexellis/k3sup/issues/174

## How Has This Been Tested?
* I made a new k3sup executable using "make"
* I executed "./k3sup app install kubernetes-dashboard"

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
