### PR TITLE
Cover app info to all commands

### DIFF
--- a/cmd/apps/certmanager_app.go
+++ b/cmd/apps/certmanager_app.go
@@ -116,21 +116,22 @@ func MakeInstallCertManager() *cobra.Command {
 			return fmt.Errorf("Error applying templated YAML files, error: %s", applyRes.Stderr)
 		}
 
-		fmt.Println(`=======================================================================
-= cert-manager has been installed.                                    =
-=======================================================================
-
-# Get started with cert-manager here:
-# https://docs.cert-manager.io/en/latest/tutorials/acme/http-validation.html
-
-# Check cert-manager's logs with:
-
-kubectl logs -n cert-manager deploy/cert-manager -f
-
-` + pkg.ThanksForUsing)
+		fmt.Println(certManagerInstallMsg)
 
 		return nil
 	}
 
 	return certManager
 }
+
+const CertManagerInfoMsg = `# Get started with cert-manager here:
+# https://docs.cert-manager.io/en/latest/tutorials/acme/http-validation.html
+
+# Check cert-manager's logs with:
+
+kubectl logs -n cert-manager deploy/cert-manager -f`
+
+const certManagerInstallMsg = `=======================================================================
+= cert-manager  has been installed.                                   =
+=======================================================================` +
+	"\n\n" + CertManagerInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/apps/cronconnector_app.go
+++ b/cmd/apps/cronconnector_app.go
@@ -117,11 +117,15 @@ func MakeInstallCronConnector() *cobra.Command {
 			return err
 		}
 
-		fmt.Println(`=======================================================================
-= cron-connector has been installed.                                   =
-=======================================================================
+		fmt.Println(cronConnectorInstallMsg)
 
-# Example usage to trigger nodeinfo every 5 minutes:
+		return nil
+	}
+
+	return command
+}
+
+const CronConnectorInfoMsg = `# Example usage to trigger nodeinfo every 5 minutes:
 
 faas-cli store deploy nodeinfo \
   --annotation schedule="*/5 * * * *" \
@@ -133,12 +137,9 @@ kubectl logs deploy/cron-connector -n openfaas -f
 
 # Find out more on the project homepage:
 
-# https://github.com/openfaas-incubator/cron-connector/
+# https://github.com/openfaas-incubator/cron-connector/`
 
-` + pkg.ThanksForUsing)
-
-		return nil
-	}
-
-	return command
-}
+const cronConnectorInstallMsg = `=======================================================================
+= cron-connector has been installed.                                  =
+=======================================================================` +
+	"\n\n" + CronConnectorInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/apps/crossplane_app.go
+++ b/cmd/apps/crossplane_app.go
@@ -129,21 +129,21 @@ schedule workloads to any Kubernetes cluster`,
 			}
 		}
 
-		fmt.Println(`
-=======================================================================
-= Crossplane has been installed.                                      =
-=======================================================================
-
-Get started by installing a stack for your favorite provider:
-* stack-gcp: https://crossplane.io/docs/master/install-crossplane.html#gcp-stack
-* stack-aws: https://crossplane.io/docs/master/install-crossplane.html#aws-stack
-* stack-azure: https://crossplane.io/docs/master/install-crossplane.html#azure-stack
-
-Learn more about Crossplane: https://crossplaneio.github.io/docs/
-
-` + pkg.ThanksForUsing)
+		fmt.Println(crossplaneInstallMsg)
 		return nil
 	}
 
 	return crossplane
 }
+
+const CrossplanInfoMsg = `# Get started by installing a stack for your favorite provider:
+* stack-gcp: https://crossplane.io/docs/master/install-crossplane.html#gcp-stack
+* stack-aws: https://crossplane.io/docs/master/install-crossplane.html#aws-stack
+* stack-azure: https://crossplane.io/docs/master/install-crossplane.html#azure-stack
+
+Learn more about Crossplane: https://crossplaneio.github.io/docs/`
+
+const crossplaneInstallMsg = `=======================================================================
+= Crossplane has been installed.                                      =
+=======================================================================` +
+	"\n\n" + CrossplanInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/apps/istio_app.go
+++ b/cmd/apps/istio_app.go
@@ -141,13 +141,13 @@ func MakeInstallIstio() *cobra.Command {
 	return istio
 }
 
-const istioInfoMsg = `# Find out more at:
+const IstioInfoMsg = `# Find out more at:
 # https://github.com/istio/`
 
 const istioPostInstallMsg = `=======================================================================
 = Istio has been installed.                                        =
 =======================================================================` +
-	"\n\n" + istioInfoMsg + "\n\n" + pkg.ThanksForUsing
+	"\n\n" + IstioInfoMsg + "\n\n" + pkg.ThanksForUsing
 
 func writeIstioValues() (string, error) {
 	out := `#

--- a/cmd/apps/kafkaconnector_app.go
+++ b/cmd/apps/kafkaconnector_app.go
@@ -131,22 +131,24 @@ func MakeInstallKafkaConnector() *cobra.Command {
 			return err
 		}
 
-		fmt.Println(`=======================================================================
-= kafka-connector has been installed.                                   =
-=======================================================================
-
-# View the connector's logs:
-
-kubectl logs deploy/kafka-connector -n openfaas -f
-
-# Find out more on the project homepage:
-
-# https://github.com/openfaas-incubator/kafka-connector/
-
-` + pkg.ThanksForUsing)
+		fmt.Println(kafkaConnectorInstallMsg)
 
 		return nil
 	}
 
 	return command
 }
+
+
+const KafkaConnectorInfoMsg = `# View the connector's logs:
+
+kubectl logs deploy/kafka-connector -n openfaas -f
+
+# Find out more on the project homepage:
+
+# https://github.com/openfaas-incubator/kafka-connector/`
+
+const kafkaConnectorInstallMsg = `=======================================================================
+= kafka-connector has been installed.                                   =
+=======================================================================` +
+	"\n\n" + KafkaConnectorInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/apps/kubernetes_dashboard_app.go
+++ b/cmd/apps/kubernetes_dashboard_app.go
@@ -35,11 +35,16 @@ func MakeInstallKubernetesDashboard() *cobra.Command {
 			return err
 		}
 
-		fmt.Println(`=======================================================================
-= Kubernetes Dashboard has been installed.                                        =
-=======================================================================
+		fmt.Println(KubernetesDashboardInfoMsg)
 
-#To create the Service Account and the ClusterRoleBinding
+		return nil
+	}
+
+	return kubeDashboard
+}
+
+
+const KubernetesDashboardInfoMsg = `# To create the Service Account and the ClusterRoleBinding
 # @See https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/creating-sample-user.md#creating-sample-user
 
 cat <<EOF | kubectl apply -f -
@@ -72,12 +77,9 @@ kubectl proxy
 kubectl -n kubernetes-dashboard describe secret $(kubectl -n kubernetes-dashboard get secret | grep admin-user-token | awk '{print $1}')
 
 # Once Proxying you can navigate to the below
-http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/login
+http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/login`
 
-` + pkg.ThanksForUsing)
-
-		return nil
-	}
-
-	return kubeDashboard
-}
+const KubernetesDashboardInstallMsg = `=======================================================================
+= Kubernetes Dashboard has been installed.                            =
+=======================================================================` +
+	"\n\n" + KubernetesDashboardInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/apps/linkerd_app.go
+++ b/cmd/apps/linkerd_app.go
@@ -41,7 +41,7 @@ func MakeInstallLinkerd() *cobra.Command {
 		arch := getNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 
-		userPath, err := config.InitUserDir()
+		userPath, err := getUserPath()
 		if err != nil {
 			return err
 		}
@@ -164,3 +164,29 @@ func linkerdCli(parts ...string) (execute.ExecResult, error) {
 
 	return res, nil
 }
+
+func getUserPath() (string, error) {
+	userPath, err := config.InitUserDir()
+	return userPath, err
+}
+
+func getExportPath() string {
+	userPath, _ := getUserPath()
+	return path.Join(userPath, "bin/")
+}
+
+var LinkerdInfoMsg = `# Get the linkerd-cli
+curl -sL https://run.linkerd.io/install | sh
+
+# Find out more at:
+# https://linkerd.io
+
+# To use the Linkerd CLI set this path:
+
+export PATH=$PATH:` + getExportPath() + `
+linkerd --help`
+
+var linkerdInstallMsg = `=======================================================================
+= Linkerd has been installed.                                         =
+=======================================================================` +
+	"\n\n" + LinkerdInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/apps/minio_app.go
+++ b/cmd/apps/minio_app.go
@@ -137,11 +137,16 @@ func MakeInstallMinio() *cobra.Command {
 			return err
 		}
 
-		fmt.Println(`=======================================================================
-= minio has been installed.                                           =
-=======================================================================
+		fmt.Println(minioInstallMsg)
+		return nil
+	}
 
-# Forward the minio port to your machine
+	return minio
+}
+
+var _, clientOS = env.GetClientArch()
+
+var MinioInfoMsg = `# Forward the minio port to your machine
 kubectl port-forward -n default svc/minio 9000:9000 &
 
 # Get the access and secret key to gain access to minio
@@ -158,11 +163,9 @@ mc config host add minio http://127.0.0.1:9000 $ACCESSKEY $SECRETKEY
 # List buckets
 mc ls minio
 
-# Find out more at: https://min.io
+# Find out more at: https://min.io`
 
-` + pkg.ThanksForUsing)
-		return nil
-	}
-
-	return minio
-}
+var minioInstallMsg = `=======================================================================
+= Minio has been installed.                                           =
+=======================================================================` +
+	"\n\n" + MinioInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/apps/nginx_app.go
+++ b/cmd/apps/nginx_app.go
@@ -122,12 +122,15 @@ func MakeInstallNginx() *cobra.Command {
 			return err
 		}
 
-		fmt.Println(`=======================================================================
-= nginx-ingress has been installed.                                   =
-=======================================================================
+		fmt.Println(nginxIngressInstallMsg)
 
+		return nil
+	}
 
-# If you're using a local environment such as "minikube" or "KinD",
+	return nginx
+}
+
+const NginxIngressInfoMsg = `# If you're using a local environment such as "minikube" or "KinD",
 # then try the inlets operator with "k3sup app install inlets-operator"
 
 # If you're using a managed Kubernetes service, then you'll find
@@ -136,12 +139,9 @@ func MakeInstallNginx() *cobra.Command {
 kubectl get svc nginx-ingress-controller
 
 # Find out more at:
-# https://github.com/helm/charts/tree/master/stable/nginx-ingress
+# https://github.com/helm/charts/tree/master/stable/nginx-ingress`
 
-` + pkg.ThanksForUsing)
-
-		return nil
-	}
-
-	return nginx
-}
+const nginxIngressInstallMsg = `=======================================================================
+= nginx-ingress has been installed.                                   =
+=======================================================================` +
+	"\n\n" + NginxIngressInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/apps/openfaas_ingress_app.go
+++ b/cmd/apps/openfaas_ingress_app.go
@@ -82,34 +82,7 @@ Have you got OpenFaaS running in the openfaas namespace and cert-manager 0.11.0 
 				res.Stderr)
 		}
 
-		fmt.Println(`=======================================================================
-= OpenFaaS Ingress and cert-manager ClusterIssuer have been installed  =
-=======================================================================
-
-# You will need to ensure that your domain points to your cluster and is
-# accessible through ports 80 and 443. 
-#
-# This is used to validate your ownership of this domain by LetsEncrypt
-# and then you can use https with your installation. 
-
-# Ingress to your domain has been installed for OpenFaaS
-# to see the ingress record run
-kubectl get -n openfaas ingress openfaas-gateway
-
-# Check the cert-manager logs with:
-kubectl logs -n cert-manager deploy/cert-manager
-
-# A cert-manager ClusterIssuer has been installed into the default
-# namespace - to see the resource run
-kubectl describe ClusterIssuer letsencrypt-prod
-
-# To check the status of your certificate you can run
-kubectl describe -n openfaas Certificate openfaas-gateway
-
-# It may take a while to be issued by LetsEncrypt, in the meantime a 
-# self-signed cert will be installed
-
-` + pkg.ThanksForUsing)
+		fmt.Println(openfaasIngressInstallMsg)
 
 		return nil
 	}
@@ -169,6 +142,34 @@ func buildYAML(domain, email, ingressClass string) ([]byte, error) {
 
 	return tpl.Bytes(), nil
 }
+
+const OpenfaasIngressInfoMsg = `# You will need to ensure that your domain points to your cluster and is
+# accessible through ports 80 and 443. 
+#
+# This is used to validate your ownership of this domain by LetsEncrypt
+# and then you can use https with your installation. 
+
+# Ingress to your domain has been installed for OpenFaaS
+# to see the ingress record run
+kubectl get -n openfaas ingress openfaas-gateway
+
+# Check the cert-manager logs with:
+kubectl logs -n cert-manager deploy/cert-manager
+
+# A cert-manager ClusterIssuer has been installed into the default
+# namespace - to see the resource run
+kubectl describe ClusterIssuer letsencrypt-prod
+
+# To check the status of your certificate you can run
+kubectl describe -n openfaas Certificate openfaas-gateway
+
+# It may take a while to be issued by LetsEncrypt, in the meantime a 
+# self-signed cert will be installed`
+
+const openfaasIngressInstallMsg = `=======================================================================
+= OpenFaaS Ingress and cert-manager ClusterIssuer have been installed =
+=======================================================================` +
+	"\n\n" + OpenfaasIngressInfoMsg + "\n\n" + pkg.ThanksForUsing
 
 var ingressYamlTemplate = `
 apiVersion: extensions/v1beta1 

--- a/cmd/apps/postgres_app.go
+++ b/cmd/apps/postgres_app.go
@@ -117,11 +117,14 @@ func MakeInstallPostgresql() *cobra.Command {
 			return err
 		}
 
-		fmt.Println(`=======================================================================
-= postgresql has been installed.                                      =
-=======================================================================
+		fmt.Println(postgresqlInstallMsg)
+		return nil
+	}
 
-PostgreSQL can be accessed via port 5432 on the following DNS name from within your cluster:
+	return postgresql
+}
+
+const PostgresqlInfoMsg = `PostgreSQL can be accessed via port 5432 on the following DNS name from within your cluster:
 
 	postgresql.default.svc.cluster.local - Read/Write connection
 
@@ -138,11 +141,9 @@ To connect to your database from outside the cluster execute the following comma
     kubectl port-forward --namespace default svc/postgresql 5432:5432 &
 	PGPASSWORD="$POSTGRES_PASSWORD" psql --host 127.0.0.1 -U postgres -d postgres -p 5432
 
-# Find out more at: https://github.com/helm/charts/tree/master/stable/postgresql
+# Find out more at: https://github.com/helm/charts/tree/master/stable/postgresql`
 
-` + pkg.ThanksForUsing)
-		return nil
-	}
-
-	return postgresql
-}
+const postgresqlInstallMsg = `=======================================================================
+= PostgreSQL has been installed.                                      =
+=======================================================================` +
+	"\n\n" + PostgresqlInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/apps/tiller_app.go
+++ b/cmd/apps/tiller_app.go
@@ -8,7 +8,6 @@ import (
 
 	execute "github.com/alexellis/go-execute/pkg/v1"
 	"github.com/alexellis/k3sup/pkg"
-	"github.com/alexellis/k3sup/pkg/config"
 	"github.com/alexellis/k3sup/pkg/env"
 	"github.com/alexellis/k3sup/pkg/helm"
 	"github.com/spf13/cobra"
@@ -39,7 +38,7 @@ func MakeInstallTiller() *cobra.Command {
 			return fmt.Errorf("This app is not known to work with the %s architecture", arch)
 		}
 
-		userPath, err := config.InitUserDir()
+		userPath, err := getUserPath()
 		if err != nil {
 			return err
 		}
@@ -82,23 +81,29 @@ func MakeInstallTiller() *cobra.Command {
 
 		fmt.Println(res.Stdout, res.Stderr)
 
-		helmBinary, err := helm.TryDownloadHelm(userPath, clientArch, clientOS, false)
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, false)
 		if err != nil {
 			return err
 		}
 
-		fmt.Println(`=======================================================================
-tiller has been installed
-=======================================================================
-
-# You can now use helm with tiller from the installation directory
-
-` + helmBinary + `
-
-` + pkg.ThanksForUsing)
+		fmt.Println(tillerInstallMsg)
 
 		return nil
 	}
 
 	return tiller
 }
+
+func getHelmBinaryPath() string {
+	userPath, _ := getUserPath()
+	helmBinaryPath := path.Join(path.Join(userPath, "bin"), "helm")
+	return helmBinaryPath
+}
+
+var TillerInfoMsg = `# You can now use helm with tiller from the installation directory
+` + getHelmBinaryPath()
+
+var tillerInstallMsg = `=======================================================================
+= tiller has been installed.                   	                      =
+=======================================================================` +
+	"\n\n" + TillerInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -35,18 +35,54 @@ k3sup app info --help`,
 		appName := args[0]
 
 		switch appName {
-		case "inlets-operator":
-			fmt.Printf("Info for app: %s\n", appName)
-			fmt.Println(apps.InletsOperatorInfoMsg)
 		case "openfaas":
 			fmt.Printf("Info for app: %s\n", appName)
 			fmt.Println(apps.OpenFaaSInfoMsg)
+		case "nginx-ingress":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.NginxIngressInfoMsg)
+		case "cert-manager":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.CertManagerInfoMsg)
+		case "openfaas-ingress":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.OpenfaasIngressInfoMsg)
+		case "inlets-operator":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.InletsOperatorInfoMsg)
 		case "mongodb":
 			fmt.Printf("Info for app: %s\n", appName)
 			fmt.Println(apps.MongoDBInfoMsg)
 		case "metrics-server":
 			fmt.Printf("Info for app: %s\n", appName)
 			fmt.Println(apps.MetricsInfoMsg)
+		case "tiller":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.TillerInfoMsg)
+		case "linkerd":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.LinkerdInfoMsg)
+		case "cron-connector":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.CronConnectorInfoMsg)
+		case "kafka-connector":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.KafkaConnectorInfoMsg)
+		case "minio":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.MinioInfoMsg)
+		case "postgresql":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.PostgresqlInfoMsg)
+		case "kubernetes-dashboard":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.KubernetesDashboardInfoMsg)
+		case "istio":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.IstioInfoMsg)
+		case "crossplane":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.CrossplanInfoMsg)
 		default:
 			return fmt.Errorf("no info available for app: %s", appName)
 		}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -11,7 +11,7 @@ import (
 
 // GetClientArch returns a pair of arch and os
 func GetClientArch() (string, string) {
-	task := execute.ExecTask{Command: "uname", Args: []string{"-m"}, StreamStdio: true}
+	task := execute.ExecTask{Command: "uname", Args: []string{"-m"}, StreamStdio: false}
 	res, err := task.Execute()
 	if err != nil {
 		log.Println(err)
@@ -19,7 +19,7 @@ func GetClientArch() (string, string) {
 
 	arch := strings.TrimSpace(res.Stdout)
 
-	taskOS := execute.ExecTask{Command: "uname", Args: []string{"-s"}, StreamStdio: true}
+	taskOS := execute.ExecTask{Command: "uname", Args: []string{"-s"}, StreamStdio: false}
 	resOS, errOS := taskOS.Execute()
 	if errOS != nil {
 		log.Println(errOS)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Refer to issue #133. Add ``app info NAME`` command to the rest of apps 

## Description
<!--- Describe your changes in detail -->
- Added app info nginx-ingress, cert-manager, metrics-server, tiller, linkerd, cron-connector, kafka-connector, minio, postgresql, kubernetes-dashboard, istio, crossplane
- Added a bool parameter ``streamStdio`` to function ``GetClientArch`` in ``pkg/env``. Currently StreamStdio is hardcored as ``true``. Running ``app minio info`` will print out clientArch and clientOS. 
Hence, I added this to suppress the unwanted output.
- Added ``mongodb`` to "Apps that you can install today" in README.md. It's missing. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
```
$ make dist
```
```
$ bin/k3sup-darwin app info nginx-ingress
```

```
Info for app: nginx-ingress
# If you're using a local environment such as "minikube" or "KinD",
# then try the inlets operator with "k3sup app install inlets-operator"

# If you're using a managed Kubernetes service, then you'll find
# your LoadBalancer's IP under "EXTERNAL-IP" via:

kubectl get svc nginx-ingress-controller

# Find out more at:
# https://github.com/helm/charts/tree/master/stable/nginx-ingress
```

```
$ bin/k3sup-darwin app info cert-manager
```

```
Info for app: cert-manager
# Get started with cert-manager here:
# https://docs.cert-manager.io/en/latest/tutorials/acme/http-validation.html

# Check cert-manager's logs with:

kubectl logs -n cert-manager deploy/cert-manager -f
```

```
$ bin/k3sup-darwin app info metrics-server
```

```
Info for app: metrics-server
# Check pod usage

kubectl top pod

# Check node usage

kubectl top node


# Find out more at:
# https://github.com/helm/charts/tree/master/stable/metrics-server
```

```
$ bin/k3sup-darwin app info tiller
```

```
Info for app: tiller
# You can now use helm with tiller from the installation directory
/Users/wingkwong/.k3sup/bin/helm
```

```
$ bin/k3sup-darwin app info linkerd
```

```
Info for app: linkerd
# Get the linkerd-cli
curl -sL https://run.linkerd.io/install | sh

# Find out more at:
# https://linkerd.io

# To use the Linkerd CLI set this path:

export PATH=$PATH:/Users/wingkwong/.k3sup/bin
linkerd --help
```

```
$ bin/k3sup-darwin app info cron-connector
```

```
Info for app: cron-connector
# Example usage to trigger nodeinfo every 5 minutes:

faas-cli store deploy nodeinfo \
  --annotation schedule="*/5 * * * *" \
  --annotation topic=cron-function

# View the connector's logs:

kubectl logs deploy/cron-connector -n openfaas -f

# Find out more on the project homepage:

# https://github.com/openfaas-incubator/cron-connector/
```

```
$ bin/k3sup-darwin app info kafka-connector
```

```
Info for app: kafka-connector
# View the connector's logs:

kubectl logs deploy/kafka-connector -n openfaas -f

# Find out more on the project homepage:

# https://github.com/openfaas-incubator/kafka-connector/
```

```
$ bin/k3sup-darwin app info minio
```

```
Info for app: minio
# Forward the minio port to your machine
kubectl port-forward -n default svc/minio 9000:9000 &

# Get the access and secret key to gain access to minio
ACCESSKEY=$(kubectl get secret -n default minio -o jsonpath="{.data.accesskey}" | base64 --decode; echo)
SECRETKEY=$(kubectl get secret -n default minio -o jsonpath="{.data.secretkey}" | base64 --decode; echo)

# Get the Minio Client
curl -SLf https://dl.min.io/client/mc/release/darwin-amd64/mc \
  && chmod +x mc

# Add a host
mc config host add minio http://127.0.0.1:9000 $ACCESSKEY $SECRETKEY

# List buckets
mc ls minio

# Find out more at: https://min.io
```

```
$ bin/k3sup-darwin app info postgresql
```

```
Info for app: postgresql
PostgreSQL can be accessed via port 5432 on the following DNS name from within your cluster:

        postgresql.default.svc.cluster.local - Read/Write connection

To get the password for "postgres" run:

    export POSTGRES_PASSWORD=$(kubectl get secret --namespace default postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)

To connect to your database run the following command:

    kubectl run postgresql-client --rm --tty -i --restart='Never' --namespace default --image docker.io/bitnami/postgresql:11.6.0-debian-9-r0 --env="PGPASSWORD=$POSTGRES_PASSWORD" --command -- psql --host postgresql -U postgres -d postgres -p 5432

To connect to your database from outside the cluster execute the following commands:

    kubectl port-forward --namespace default svc/postgresql 5432:5432 &
        PGPASSWORD="$POSTGRES_PASSWORD" psql --host 127.0.0.1 -U postgres -d postgres -p 5432

# Find out more at: https://github.com/helm/charts/tree/master/stable/postgresql
```

```
$ bin/k3sup-darwin app info kubernetes-dashboard
```

```
Info for app: kubernetes-dashboard
# To create the Service Account and the ClusterRoleBinding
# @See https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/creating-sample-user.md#creating-sample-user

cat <<EOF | kubectl apply -f -
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: admin-user
  namespace: kubernetes-dashboard
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: admin-user
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cluster-admin
subjects:
- kind: ServiceAccount
  name: admin-user
  namespace: kubernetes-dashboard
---
EOF

#To forward the dashboard to your local machine 
kubectl proxy

#To get your Token for logging in
kubectl -n kubernetes-dashboard describe secret $(kubectl -n kubernetes-dashboard get secret | grep admin-user-token | awk '{print $1}')

# Once Proxying you can navigate to the below
http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/login
```

```
$ bin/k3sup-darwin app info istio
```

```
Info for app: istio
# Find out more at:
# https://github.com/istio/
```

```
$ bin/k3sup-darwin app info crossplane
```
```
Info for app: crossplane
# Get started by installing a stack for your favorite provider:
* stack-gcp: https://crossplane.io/docs/master/install-crossplane.html#gcp-stack
* stack-aws: https://crossplane.io/docs/master/install-crossplane.html#aws-stack
* stack-azure: https://crossplane.io/docs/master/install-crossplane.html#azure-stack

Learn more about Crossplane: https://crossplaneio.github.io/docs/
```

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
