### PR TITLE
Switch to helm3

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -13,11 +13,10 @@ func MakeApps() *cobra.Command {
 		Use:   "app",
 		Short: "Install Kubernetes apps from helm charts or YAML files",
 		Long: `Install Kubernetes apps from helm charts or YAML files using the "install" 
-command. Helm 2 is used by default unless a --helm3 flag exists and is passed. 
-You can also find the post-install message for each app with the "info" 
+command. Helm 3 is used by default. You can also find the post-install message for each app with the "info" 
 command.`,
 		Example: `  k3sup app install
-  k3sup app install openfaas --helm3 --gateways=2
+  k3sup app install openfaas --gateways=2
   k3sup app info inlets-operator`,
 		SilenceUsage: false,
 	}

--- a/cmd/apps/certmanager_app.go
+++ b/cmd/apps/certmanager_app.go
@@ -53,12 +53,12 @@ func MakeInstallCertManager() *cobra.Command {
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, false)
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
 		if err != nil {
 			return err
 		}
 
-		err = addHelmRepo("jetstack", "https://charts.jetstack.io", false)
+		err = addHelmRepo("jetstack", "https://charts.jetstack.io")
 		if err != nil {
 			return err
 		}
@@ -66,7 +66,7 @@ func MakeInstallCertManager() *cobra.Command {
 		updateRepo, _ := certManager.Flags().GetBool("update-repo")
 
 		if updateRepo {
-			err = updateHelmRepos(false)
+			err = updateHelmRepos()
 			if err != nil {
 				return err
 			}
@@ -83,7 +83,7 @@ func MakeInstallCertManager() *cobra.Command {
 
 		chartPath := path.Join(os.TempDir(), "charts")
 
-		err = fetchChart(chartPath, "jetstack/cert-manager", false)
+		err = fetchChart(chartPath, "jetstack/cert-manager")
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/chart_app.go
+++ b/cmd/apps/chart_app.go
@@ -77,19 +77,19 @@ before using the generic helm chart installer command.`,
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, false)
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
 		if err != nil {
 			return err
 		}
 
 		if len(chartRepoURL) > 0 {
-			err = addHelmRepo(chartPrefix, chartRepoURL, false)
+			err = addHelmRepo(chartPrefix, chartRepoURL)
 			if err != nil {
 				return err
 			}
 		}
 
-		err = updateHelmRepos(false)
+		err = updateHelmRepos()
 		if err != nil {
 			return err
 		}
@@ -109,7 +109,7 @@ before using the generic helm chart installer command.`,
 
 		chartPath := path.Join(os.TempDir(), "charts")
 
-		err = fetchChart(chartPath, chartRepoName, false)
+		err = fetchChart(chartPath, chartRepoName)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/cronconnector_app.go
+++ b/cmd/apps/cronconnector_app.go
@@ -57,25 +57,25 @@ func MakeInstallCronConnector() *cobra.Command {
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, false)
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
 		if err != nil {
 			return err
 		}
 
-		err = addHelmRepo("openfaas", "https://openfaas.github.io/faas-netes/", false)
+		err = addHelmRepo("openfaas", "https://openfaas.github.io/faas-netes/")
 		if err != nil {
 			return err
 		}
 
 		if updateRepo {
-			err = updateHelmRepos(false)
+			err = updateHelmRepos()
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "openfaas/cron-connector", false)
+		err = fetchChart(chartPath, "openfaas/cron-connector")
 
 		if err != nil {
 			return err

--- a/cmd/apps/istio_app.go
+++ b/cmd/apps/istio_app.go
@@ -60,19 +60,14 @@ func MakeInstallIstio() *cobra.Command {
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		helm3 := true
-		if helm3 {
-			os.Setenv("HELM_VERSION", helm3Version)
-		}
-
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, helm3)
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
 		if err != nil {
 			return err
 		}
 
 		istioVer := "1.3.3"
 
-		err = addHelmRepo("istio", "https://storage.googleapis.com/istio-release/releases/"+istioVer+"/charts", helm3)
+		err = addHelmRepo("istio", "https://storage.googleapis.com/istio-release/releases/"+istioVer+"/charts")
 		if err != nil {
 			return fmt.Errorf("unable to add repo %s", err)
 		}
@@ -80,7 +75,7 @@ func MakeInstallIstio() *cobra.Command {
 		updateRepo, _ := istio.Flags().GetBool("update-repo")
 
 		if updateRepo {
-			err = updateHelmRepos(helm3)
+			err = updateHelmRepos()
 			if err != nil {
 				return fmt.Errorf("unable to update repos %s", err)
 			}
@@ -94,7 +89,7 @@ func MakeInstallIstio() *cobra.Command {
 
 		chartPath := path.Join(os.TempDir(), "charts")
 
-		err = fetchChart(chartPath, "istio/istio", helm3)
+		err = fetchChart(chartPath, "istio/istio")
 
 		if err != nil {
 			return fmt.Errorf("unable fetch chart %s", err)
@@ -112,7 +107,7 @@ func MakeInstallIstio() *cobra.Command {
 		wait := true
 
 		if initIstio, _ := command.Flags().GetBool("init"); initIstio {
-			err = helm3Upgrade(outputPath, "istio/istio-init", namespace, "", overrides, wait)
+			err = helmUpgrade(outputPath, "istio/istio-init", namespace, "", overrides, wait)
 			if err != nil {
 				return fmt.Errorf("unable to istio-init install chart with helm %s", err)
 			}
@@ -128,7 +123,7 @@ func MakeInstallIstio() *cobra.Command {
 			return err
 		}
 
-		err = helm3Upgrade(outputPath, "istio/istio", namespace, valuesFile, overrides, wait)
+		err = helmUpgrade(outputPath, "istio/istio", namespace, valuesFile, overrides, wait)
 		if err != nil {
 			return fmt.Errorf("unable to istio install chart with helm %s", err)
 		}

--- a/cmd/apps/kafkaconnector_app.go
+++ b/cmd/apps/kafkaconnector_app.go
@@ -58,25 +58,25 @@ func MakeInstallKafkaConnector() *cobra.Command {
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, false)
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
 		if err != nil {
 			return err
 		}
 
-		err = addHelmRepo("openfaas", "https://openfaas.github.io/faas-netes/", false)
+		err = addHelmRepo("openfaas", "https://openfaas.github.io/faas-netes/")
 		if err != nil {
 			return err
 		}
 
 		if updateRepo {
-			err = updateHelmRepos(false)
+			err = updateHelmRepos()
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "openfaas/kafka-connector", false)
+		err = fetchChart(chartPath, "openfaas/kafka-connector")
 
 		if err != nil {
 			return err

--- a/cmd/apps/kubernetes_exec.go
+++ b/cmd/apps/kubernetes_exec.go
@@ -11,12 +11,9 @@ import (
 	"github.com/alexellis/k3sup/pkg/env"
 )
 
-func fetchChart(path, chart string, helm3 bool) error {
+func fetchChart(path, chart string) error {
 
 	subdir := ""
-	if helm3 {
-		subdir = "helm3"
-	}
 
 	mkErr := os.MkdirAll(path, 0700)
 
@@ -49,7 +46,7 @@ func getNodeArchitecture() string {
 	return arch
 }
 
-func helm3Upgrade(basePath, chart, namespace, values string, overrides map[string]string, wait bool) error {
+func helmUpgrade(basePath, chart, namespace, values string, overrides map[string]string, wait bool) error {
 
 	chartName := chart
 	if index := strings.Index(chartName, "/"); index > -1 {
@@ -74,8 +71,10 @@ func helm3Upgrade(basePath, chart, namespace, values string, overrides map[strin
 		args = append(args, fmt.Sprintf("%s=%s", k, v))
 	}
 
+	subdir := ""
+
 	task := execute.ExecTask{
-		Command:     env.LocalBinary("helm", "helm3"),
+		Command:     env.LocalBinary("helm", subdir),
 		Args:        args,
 		Env:         os.Environ(),
 		Cwd:         basePath,
@@ -150,11 +149,8 @@ func templateChart(basePath, chart, namespace, outputPath, values string, overri
 	return nil
 }
 
-func addHelmRepo(name, url string, helm3 bool) error {
+func addHelmRepo(name, url string) error {
 	subdir := ""
-	if helm3 {
-		subdir = "helm3"
-	}
 
 	task := execute.ExecTask{
 		Command:     fmt.Sprintf("%s repo add %s %s", env.LocalBinary("helm", subdir), name, url),
@@ -173,11 +169,9 @@ func addHelmRepo(name, url string, helm3 bool) error {
 	return nil
 }
 
-func updateHelmRepos(helm3 bool) error {
+func updateHelmRepos() error {
 	subdir := ""
-	if helm3 {
-		subdir = "helm3"
-	}
+
 	task := execute.ExecTask{
 		Command:     fmt.Sprintf("%s repo update", env.LocalBinary("helm", subdir)),
 		Env:         os.Environ(),

--- a/cmd/apps/minio_app.go
+++ b/cmd/apps/minio_app.go
@@ -62,20 +62,20 @@ func MakeInstallMinio() *cobra.Command {
 			return fmt.Errorf("please use the helm chart if you'd like to change the namespace to %s", ns)
 		}
 
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, false)
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
 		if err != nil {
 			return err
 		}
 
 		if updateRepo {
-			err = updateHelmRepos(false)
+			err = updateHelmRepos()
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "stable/minio", false)
+		err = fetchChart(chartPath, "stable/minio")
 
 		if err != nil {
 			return err

--- a/cmd/apps/mongodb_app.go
+++ b/cmd/apps/mongodb_app.go
@@ -50,16 +50,13 @@ func MakeInstallMongoDB() *cobra.Command {
 		log.Printf("User dir established as: %s\n", userPath)
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
-		os.Setenv("HELM_VERSION", helm3Version)
 
-		helm3 := true
-
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, helm3)
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
 		if err != nil {
 			return err
 		}
 
-		err = addHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com/", helm3)
+		err = addHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com/")
 		if err != nil {
 			return fmt.Errorf("unable to add repo %s", err)
 		}
@@ -67,7 +64,7 @@ func MakeInstallMongoDB() *cobra.Command {
 		updateRepo, _ := command.Flags().GetBool("update-repo")
 
 		if updateRepo {
-			err = updateHelmRepos(helm3)
+			err = updateHelmRepos()
 			if err != nil {
 				return fmt.Errorf("unable to update repos %s", err)
 			}
@@ -75,7 +72,7 @@ func MakeInstallMongoDB() *cobra.Command {
 
 		chartPath := path.Join(os.TempDir(), "charts")
 
-		err = fetchChart(chartPath, "stable/mongodb", helm3)
+		err = fetchChart(chartPath, "stable/mongodb")
 
 		if err != nil {
 			return fmt.Errorf("unable fetch chart %s", err)
@@ -94,7 +91,7 @@ func MakeInstallMongoDB() *cobra.Command {
 			return err
 		}
 
-		err = helm3Upgrade(outputPath, "stable/mongodb",
+		err = helmUpgrade(outputPath, "stable/mongodb",
 			namespace, "values.yaml", overrides, false)
 		if err != nil {
 			return fmt.Errorf("unable to mongodb chart with helm %s", err)

--- a/cmd/apps/nginx_app.go
+++ b/cmd/apps/nginx_app.go
@@ -54,20 +54,20 @@ func MakeInstallNginx() *cobra.Command {
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, false)
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
 		if err != nil {
 			return err
 		}
 
 		if updateRepo {
-			err = updateHelmRepos(false)
+			err = updateHelmRepos()
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "stable/nginx-ingress", false)
+		err = fetchChart(chartPath, "stable/nginx-ingress")
 
 		if err != nil {
 			return err

--- a/cmd/apps/postgres_app.go
+++ b/cmd/apps/postgres_app.go
@@ -60,20 +60,20 @@ func MakeInstallPostgresql() *cobra.Command {
 			return fmt.Errorf("please use the helm chart if you'd like to change the namespace to %s", ns)
 		}
 
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, false)
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
 		if err != nil {
 			return err
 		}
 
 		if updateRepo {
-			err = updateHelmRepos(false)
+			err = updateHelmRepos()
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "stable/postgresql", false)
+		err = fetchChart(chartPath, "stable/postgresql")
 
 		if err != nil {
 			return err

--- a/cmd/apps/tiller_app.go
+++ b/cmd/apps/tiller_app.go
@@ -81,7 +81,7 @@ func MakeInstallTiller() *cobra.Command {
 
 		fmt.Println(res.Stdout, res.Stderr)
 
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, false)
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
 		if err != nil {
 			return err
 		}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -13,28 +13,17 @@ import (
 	"github.com/alexellis/k3sup/pkg/env"
 )
 
-const helmVersion = "v2.16.0"
+const helmVersion = "v3.0.2"
 
-func TryDownloadHelm(userPath, clientArch, clientOS string, helm3 bool) (string, error) {
+func TryDownloadHelm(userPath, clientArch, clientOS string) (string, error) {
 	helmVal := "helm"
-	if helm3 {
-		helmVal = "helm3"
-	}
 
 	helmBinaryPath := path.Join(path.Join(userPath, "bin"), helmVal)
 	if _, statErr := os.Stat(helmBinaryPath); statErr != nil {
 		subdir := ""
-		if helm3 {
-			subdir = "helm3"
-		}
+
 		DownloadHelm(userPath, clientArch, clientOS, subdir)
 
-		if !helm3 {
-			err := HelmInit()
-			if err != nil {
-				return "", err
-			}
-		}
 	}
 	return helmBinaryPath, nil
 }


### PR DESCRIPTION
Closes #107

Switch to helm3 as it is backward compatible with helm2 see section "Compatibility with Helm 2" in https://github.com/helm/helm/releases/tag/v3.0.0


## Description

- [x] Removed reference to helm3
- [x] Make helm3 default instalation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Simplify codebase and move forward with helm3 which doesn't need template export workaround to avoid tiller installation.

<!--- If it fixes an open issue, please link to the issue here. -->
- [x] https://github.com/alexellis/k3sup/issues/107

## How Has This Been Tested?
<details>
 <summary>Install faas using helm3</summary>

```bash
k3sup on  feature/switch_to_helm3 via 🐹 v1.13.6 at ☸️  default took 7s 
➜ make test
CGO_ENABLED=0 go test github.com/alexellis/k3sup github.com/alexellis/k3sup/cmd github.com/alexellis/k3sup/cmd/apps github.com/alexellis/k3sup/pkg github.com/alexellis/k3sup/pkg/config github.com/alexellis/k3sup/pkg/env github.com/alexellis/k3sup/pkg/helm github.com/alexellis/k3sup/pkg/operator -cover
?       github.com/alexellis/k3sup      [no test files]
ok      github.com/alexellis/k3sup/cmd  0.196s  coverage: 7.5% of statements
ok      github.com/alexellis/k3sup/cmd/apps     0.313s  coverage: 2.8% of statements
?       github.com/alexellis/k3sup/pkg  [no test files]
?       github.com/alexellis/k3sup/pkg/config   [no test files]
?       github.com/alexellis/k3sup/pkg/env      [no test files]
?       github.com/alexellis/k3sup/pkg/helm     [no test files]
?       github.com/alexellis/k3sup/pkg/operator [no test files]

k3sup on  feature/switch_to_helm3 via 🐹 v1.13.6 at ☸️  default took 3s 
➜ make build
go build

k3sup on  feature/switch_to_helm3 via 🐹 v1.13.6 
➜ ./k3sup install --ip 10.236.64.56 --user root       
Running: k3sup install
Public IP: 10.236.64.56
ssh -i /Users/Mario.Vejlupek/.ssh/id_rsa -p 22 root@10.236.64.56
ssh: curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server  --tls-san 10.236.64.56 ' INSTALL_K3S_VERSION='v1.17.2+k3s1' sh -

[INFO]  Using v1.17.2+k3s1 as release
[INFO]  Downloading hash https://github.com/rancher/k3s/releases/download/v1.17.2+k3s1/sha256sum-arm.txt
[INFO]  Downloading binary https://github.com/rancher/k3s/releases/download/v1.17.2+k3s1/k3s-armhf[INFO]  Verifying binary download
[INFO]  Installing k3s to /usr/local/bin/k3s
[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
[INFO]  Creating /usr/local/bin/crictl symlink to k3s
[INFO]  Skipping /usr/local/bin/ctr symlink to k3s, command exists in PATH at /usr/bin/ctr
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
[INFO]  systemd: Enabling k3s unit
Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.
[INFO]  systemd: Starting k3s
Result: [INFO]  Using v1.17.2+k3s1 as release
[INFO]  Downloading hash https://github.com/rancher/k3s/releases/download/v1.17.2+k3s1/sha256sum-arm.txt
[INFO]  Downloading binary https://github.com/rancher/k3s/releases/download/v1.17.2+k3s1/k3s-armhf
[INFO]  Verifying binary download
[INFO]  Installing k3s to /usr/local/bin/k3s
[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
[INFO]  Creating /usr/local/bin/crictl symlink to k3s
[INFO]  Skipping /usr/local/bin/ctr symlink to k3s, command exists in PATH at /usr/bin/ctr
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
[INFO]  systemd: Enabling k3s unit
[INFO]  systemd: Starting k3s
 Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.

ssh: sudo cat /etc/rancher/k3s/k3s.yaml

apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJWekNCL3FBREFnRUNBZ0VBTUFvR0NDcUdTTTQ5QkFNQ01DTXhJVEFmQmdOVkJBTU1HR3N6Y3kxelpYSjIKWlhJdFkyRkFNVFU0TVRFMU56azRNakFlRncweU1EQXlNRGd4TURNek1ESmFGdzB6TURBeU1EVXhNRE16TURKYQpNQ014SVRBZkJnTlZCQU1NR0dzemN5MXpaWEoyWlhJdFkyRkFNVFU0TVRFMU56azRNakJaTUJNR0J5cUdTTTQ5CkFnRUdDQ3FHU000OUF3RUhBMElBQkpLSi8rc0tDUVlxVjFTZlYveEhQaEtPZWFwTXBhNTJ4cTRiMnlrSndKMSsKeDIxd3FQY0g0SkZyWGVhNVBXTFFNVHhYRVhVcFZuaXQyWGhOSFlsbHl2cWpJekFoTUE0R0ExVWREd0VCL3dRRQpBd0lDcERBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUFvR0NDcUdTTTQ5QkFNQ0EwZ0FNRVVDSVFEWXVTU2JBLzdoCitBMGRYS2o1dDYvcVZ4K0NpRHlraW1RdjIxQWdWSTJTWEFJZ01zVTdnSWcwV0FpbXlJc2l6N3JSd013dnVRb0UKSC9kdDFEbCthZjRlMytnPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
    server: https://127.0.0.1:6443
  name: default
contexts:
- context:
    cluster: default
    user: default
  name: default
current-context: default
kind: Config
preferences: {}
users:
- name: default
  user:
    password: 62b1e06a7df8ed08fe8970c872f69fe8
    username: admin
Result: apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJWekNCL3FBREFnRUNBZ0VBTUFvR0NDcUdTTTQ5QkFNQ01DTXhJVEFmQmdOVkJBTU1HR3N6Y3kxelpYSjIKWlhJdFkyRkFNVFU0TVRFMU56azRNakFlRncweU1EQXlNRGd4TURNek1ESmFGdzB6TURBeU1EVXhNRE16TURKYQpNQ014SVRBZkJnTlZCQU1NR0dzemN5MXpaWEoyWlhJdFkyRkFNVFU0TVRFMU56azRNakJaTUJNR0J5cUdTTTQ5CkFnRUdDQ3FHU000OUF3RUhBMElBQkpLSi8rc0tDUVlxVjFTZlYveEhQaEtPZWFwTXBhNTJ4cTRiMnlrSndKMSsKeDIxd3FQY0g0SkZyWGVhNVBXTFFNVHhYRVhVcFZuaXQyWGhOSFlsbHl2cWpJekFoTUE0R0ExVWREd0VCL3dRRQpBd0lDcERBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUFvR0NDcUdTTTQ5QkFNQ0EwZ0FNRVVDSVFEWXVTU2JBLzdoCitBMGRYS2o1dDYvcVZ4K0NpRHlraW1RdjIxQWdWSTJTWEFJZ01zVTdnSWcwV0FpbXlJc2l6N3JSd013dnVRb0UKSC9kdDFEbCthZjRlMytnPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
    server: https://127.0.0.1:6443
  name: default
contexts:
- context:
    cluster: default
    user: default
  name: default
current-context: default
kind: Config
preferences: {}
users:
- name: default
  user:
    password: 62b1e06a7df8ed08fe8970c872f69fe8
    username: admin
 
Saving file to: /Users/Mario.Vejlupek/go/src/github.com/elmariofredo/k3sup/kubeconfig

# Test your cluster with:
export KUBECONFIG=/Users/Mario.Vejlupek/go/src/github.com/elmariofredo/k3sup/kubeconfig
kubectl get node -o wide

k3sup on  feature/switch_to_helm3 via 🐹 v1.13.6 took 2m 41s 
➜ export KUBECONFIG=/Users/Mario.Vejlupek/go/src/github.com/elmariofredo/k3sup/kubeconfig
kubectl get node -o wide
NAME               STATUS     ROLES    AGE   VERSION        INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION   CONTAINER-RUNTIME
100000007368d69d   NotReady   master   6s    v1.17.2+k3s1   10.236.64.56   <none>        Raspbian GNU/Linux 10 (buster)   4.19.97-v7l+     containerd://1.3.3-k3s1

k3sup on  feature/switch_to_helm3 via 🐹 v1.13.6 at ☸️  default 
➜ ./k3sup join --ip 10.236.64.55 --server-ip 10.236.64.56
Running: k3sup join
Server IP: 10.236.64.56
ssh -i /Users/Mario.Vejlupek/.ssh/id_rsa -p 22 root@10.236.64.56
ssh: sudo cat /var/lib/rancher/k3s/server/node-token

K106119acf9fff49f37e208a3afca76941ffaf09671bc1cd21817fbfb692137bce4::server:a81943ed65ddce7c463220fea6457c1e
ssh: curl -sfL https://get.k3s.io/ | K3S_URL='https://10.236.64.56:6443' K3S_TOKEN='K106119acf9fff49f37e208a3afca76941ffaf09671bc1cd21817fbfb692137bce4::server:a81943ed65ddce7c463220fea6457c1e' INSTALL_K3S_VERSION='v1.17.2+k3s1' sh -s - 
[INFO]  Using v1.17.2+k3s1 as release
[INFO]  Downloading hash https://github.com/rancher/k3s/releases/download/v1.17.2+k3s1/sha256sum-arm.txt
[INFO]  Downloading binary https://github.com/rancher/k3s/releases/download/v1.17.2+k3s1/k3s-armhf
[INFO]  Verifying binary download
[INFO]  Installing k3s to /usr/local/bin/k3s
[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
[INFO]  Creating /usr/local/bin/crictl symlink to k3s
[INFO]  Skipping /usr/local/bin/ctr symlink to k3s, command exists in PATH at /usr/bin/ctr
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-agent-uninstall.sh
[INFO]  env: Creating environment file /etc/systemd/system/k3s-agent.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s-agent.service
[INFO]  systemd: Enabling k3s-agent unit
Created symlink /etc/systemd/system/multi-user.target.wants/k3s-agent.service → /etc/systemd/system/k3s-agent.service.
[INFO]  systemd: Starting k3s-agent
Logs: Created symlink /etc/systemd/system/multi-user.target.wants/k3s-agent.service → /etc/systemd/system/k3s-agent.service.
Output: [INFO]  Using v1.17.2+k3s1 as release
[INFO]  Downloading hash https://github.com/rancher/k3s/releases/download/v1.17.2+k3s1/sha256sum-arm.txt
[INFO]  Downloading binary https://github.com/rancher/k3s/releases/download/v1.17.2+k3s1/k3s-armhf
[INFO]  Verifying binary download
[INFO]  Installing k3s to /usr/local/bin/k3s
[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
[INFO]  Creating /usr/local/bin/crictl symlink to k3s
[INFO]  Skipping /usr/local/bin/ctr symlink to k3s, command exists in PATH at /usr/bin/ctr
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-agent-uninstall.sh
[INFO]  env: Creating environment file /etc/systemd/system/k3s-agent.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s-agent.service
[INFO]  systemd: Enabling k3s-agent unit
[INFO]  systemd: Starting k3s-agent

k3sup on  feature/switch_to_helm3 via 🐹 v1.13.6 at ☸️  default took 37s 
➜ export KUBECONFIG=/Users/Mario.Vejlupek/go/src/github.com/elmariofredo/k3sup/kubeconfig
kubectl get node -o wide
NAME               STATUS   ROLES    AGE     VERSION        INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION   CONTAINER-RUNTIME
100000007368d69d   Ready    master   2m27s   v1.17.2+k3s1   10.236.64.56   <none>        Raspbian GNU/Linux 10 (buster)   4.19.97-v7l+     containerd://1.3.3-k3s1
1000000035a3a9e3   Ready    <none>   39s     v1.17.2+k3s1   10.236.64.55   <none>        Raspbian GNU/Linux 10 (buster)   4.19.93-v7l+     containerd://1.3.3-k3s1

k3sup on  feature/switch_to_helm3 via 🐹 v1.13.6 at ☸️  default 
➜ ./k3sup app install openfaas                                                           
Using kubeconfig: /Users/Mario.Vejlupek/go/src/github.com/elmariofredo/k3sup/kubeconfig
armNode architecture: "arm"
x86_64
Darwin
Client: "x86_64", "Darwin"
2020/02/08 11:35:49 User dir established as: /Users/Mario.Vejlupek/.k3sup/
"openfaas" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
namespace/openfaas created
namespace/openfaas-fn created
secret/basic-auth created
VALUES values-armhf.yaml
Command: /Users/Mario.Vejlupek/.k3sup/bin/helm [upgrade --install openfaas openfaas/openfaas --namespace openfaas --values /var/folders/dr/q2nkwnb9679b49_43vwcwtkc0000gp/T/charts/openfaas/values-armhf.yaml --set gateway.replicas=1 --set queueWorker.replicas=1 --set basic_auth=true --set gateway.directFunctions=true --set openfaasImagePullPolicy=IfNotPresent --set faasnetes.imagePullPolicy=Always --set basicAuthPlugin.replicas=1 --set clusterRole=false --set operator.create=false --set serviceType=NodePort]
Release "openfaas" does not exist. Installing it now.
NAME: openfaas
LAST DEPLOYED: Sat Feb  8 11:36:18 2020
NAMESPACE: openfaas
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
To verify that openfaas has started, run:

  kubectl -n openfaas get deployments -l "release=openfaas, app=openfaas"
=======================================================================
= OpenFaaS has been installed.                                        =
=======================================================================

# Get the faas-cli
curl -SLsf https://cli.openfaas.com | sudo sh

# Forward the gateway to your machine
kubectl rollout status -n openfaas deploy/gateway
kubectl port-forward -n openfaas svc/gateway 8080:8080 &

# If basic auth is enabled, you can now log into your gateway:
PASSWORD=$(kubectl get secret -n openfaas basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode; echo)
echo -n $PASSWORD | faas-cli login --username admin --password-stdin

faas-cli store deploy figlet
faas-cli list

# For Raspberry Pi
faas-cli store list \
 --platform armhf

faas-cli store deploy figlet \
 --platform armhf

# Find out more at:
# https://github.com/openfaas/faas

Thanks for using k3sup!

k3sup on  feature/switch_to_helm3 via 🐹 v1.13.6 at ☸️  default took 37s 
➜ kubectl -n openfaas get deployments -l "release=openfaas, app=openfaas"
NAME                READY   UP-TO-DATE   AVAILABLE   AGE
nats                0/1     1            0           23s
gateway             0/1     1            0           23s
queue-worker        0/1     1            0           23s
basic-auth-plugin   0/1     1            0           23s
prometheus          0/1     1            0           23s
faas-idler          0/1     1            0           23s
alertmanager        0/1     1            0           23s

k3sup on  feature/switch_to_helm3 via 🐹 v1.13.6 at ☸️  default took 4s 
➜ kubectl -n openfaas get deployments -l "release=openfaas, app=openfaas"           
NAME                READY   UP-TO-DATE   AVAILABLE   AGE
basic-auth-plugin   1/1     1            1           2m24s
nats                1/1     1            1           2m24s
queue-worker        1/1     1            1           2m24s
faas-idler          1/1     1            1           2m24s
gateway             1/1     1            1           2m24s
prometheus          1/1     1            1           2m24s
alertmanager        1/1     1            1           2m24s


k3sup on  feature/switch_to_helm3 via 🐹 v1.13.6 at ☸️  default 
➜ kubectl rollout status -n openfaas deploy/gateway
deployment "gateway" successfully rolled out


k3sup on  feature/switch_to_helm3 via 🐹 v1.13.6 at ☸️  default took 2m 9s 
➜ kubectl port-forward -n openfaas svc/gateway 8080:8080
Forwarding from 127.0.0.1:8080 -> 8080
Forwarding from [::1]:8080 -> 8080
Handling connection for 8080
Handling connection for 8080
Handling connection for 8080
Handling connection for 8080
Handling connection for 8080
Handling connection for 8080
Handling connection for 8080
^C%                                                                                                   

k3sup on  feature/switch_to_helm3 via 🐹 v1.13.6 at ☸️  default took 42s 

➜ /Users/Mario.Vejlupek/.k3sup/bin/helm version                                         
version.BuildInfo{Version:"v3.0.2", GitCommit:"19e47ee3283ae98139d98460de796c1be1e3975f", GitTreeState:"clean", GoVersion:"go1.13.5"}
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
