### PR TITLE
Add uninstall command

### DIFF
--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+
+	operator "github.com/alexellis/k3sup/pkg/operator"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func MakeUninstall() *cobra.Command {
+	var command = &cobra.Command{
+		Use:          "uninstall",
+		Short:        "Uninstall k3s",
+		Long:         `Uninstall k3s.`,
+		Example:      `  k3sup uninstall --ip 192.168.0.100 --user ubuntu`,
+		SilenceUsage: true,
+	}
+	command.Flags().IP("ip", net.ParseIP("127.0.0.1"), "Public IP of node")
+	command.Flags().String("user", "root", "Username for SSH login")
+
+	command.Flags().String("ssh-key", "~/.ssh/id_rsa", "The ssh key to use for remote login")
+	command.Flags().Int("ssh-port", 22, "The port on which to connect for ssh")
+	command.Flags().Bool("local", false, "Perform a local install without using ssh")
+	command.Flags().Bool("sudo", true, "Use sudo for installation. e.g. set to false when using the root user and no sudo is available.")
+
+	command.RunE = func(command *cobra.Command, args []string) error {
+
+		fmt.Printf("Running: k3sup uninstall\n")
+
+		local, _ := command.Flags().GetBool("local")
+
+		ip, _ := command.Flags().GetIP("ip")
+
+		useSudo, _ := command.Flags().GetBool("sudo")
+		sudoPrefix := ""
+		if useSudo {
+			sudoPrefix = "sudo "
+		}
+
+		uninstallK3scommand := fmt.Sprintf(sudoPrefix + "/usr/local/bin/k3s-killall.sh && " + sudoPrefix + "/usr/local/bin/k3s-uninstall.sh")
+		if local {
+			operator := operator.ExecOperator{}
+
+			fmt.Printf("Executing: %s\n", uninstallK3scommand)
+
+			res, err := operator.Execute(uninstallK3scommand)
+			if err != nil {
+				return err
+			}
+
+			if len(res.StdErr) > 0 {
+				fmt.Printf("stderr: %q", res.StdErr)
+			}
+			if len(res.StdOut) > 0 {
+				fmt.Printf("stdout: %q", res.StdOut)
+			}
+
+			return nil
+		}
+
+		port, _ := command.Flags().GetInt("ssh-port")
+
+		fmt.Println("Public IP: " + ip.String())
+
+		user, _ := command.Flags().GetString("user")
+		sshKey, _ := command.Flags().GetString("ssh-key")
+
+		sshKeyPath := expandPath(sshKey)
+		fmt.Printf("ssh -i %s -p %d %s@%s\n", sshKeyPath, port, user, ip.String())
+
+		authMethod, closeSSHAgent, err := loadPublickey(sshKeyPath)
+		if err != nil {
+			return errors.Wrapf(err, "unable to load the ssh key with path %q", sshKeyPath)
+		}
+
+		defer closeSSHAgent()
+
+		config := &ssh.ClientConfig{
+			User: user,
+			Auth: []ssh.AuthMethod{
+				authMethod,
+			},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		}
+
+		address := fmt.Sprintf("%s:%d", ip.String(), port)
+		operator, err := operator.NewSSHOperator(address, config)
+
+		if err != nil {
+			return errors.Wrapf(err, "unable to connect to %s over ssh", address)
+		}
+
+		defer operator.Close()
+
+		fmt.Printf("ssh: %s\n", uninstallK3scommand)
+		res, err := operator.Execute(uninstallK3scommand)
+
+		if err != nil {
+			return fmt.Errorf("Error received processing command: %s", err)
+		}
+
+		fmt.Printf("Result: %s %s\n", string(res.StdOut), string(res.StdErr))
+
+		return nil
+
+	}
+
+	command.PreRunE = func(command *cobra.Command, args []string) error {
+		_, ipErr := command.Flags().GetIP("ip")
+		if ipErr != nil {
+			return ipErr
+		}
+
+		_, sshPortErr := command.Flags().GetInt("ssh-port")
+		if sshPortErr != nil {
+			return sshPortErr
+		}
+		return nil
+	}
+	return command
+}
+
+func uexpandPath(path string) string {
+	res, _ := homedir.Expand(path)
+	return res
+}
+
+func usshAgent(publicKeyPath string) (ssh.AuthMethod, func() error) {
+	if sshAgentConn, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK")); err == nil {
+		sshAgent := agent.NewClient(sshAgentConn)
+
+		keys, _ := sshAgent.List()
+		if len(keys) == 0 {
+			return nil, sshAgentConn.Close
+		}
+
+		pubkey, err := ioutil.ReadFile(publicKeyPath)
+		if err != nil {
+			return nil, sshAgentConn.Close
+		}
+
+		authkey, _, _, _, err := ssh.ParseAuthorizedKey(pubkey)
+		if err != nil {
+			return nil, sshAgentConn.Close
+		}
+		parsedkey := authkey.Marshal()
+
+		for _, key := range keys {
+			if bytes.Equal(key.Blob, parsedkey) {
+				return ssh.PublicKeysCallback(sshAgent.Signers), sshAgentConn.Close
+			}
+		}
+	}
+	return nil, func() error { return nil }
+}
+
+func uloadPublickey(path string) (ssh.AuthMethod, func() error, error) {
+	noopCloseFunc := func() error { return nil }
+
+	key, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, noopCloseFunc, err
+	}
+
+	signer, err := ssh.ParsePrivateKey(key)
+	if err != nil {
+		if err.Error() != "ssh: cannot decode encrypted private keys" {
+			return nil, noopCloseFunc, err
+		}
+
+		agent, close := sshAgent(path + ".pub")
+		if agent != nil {
+			return agent, close, nil
+		}
+
+		defer close()
+
+		fmt.Printf("Enter passphrase for '%s': ", path)
+		bytePassword, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+		fmt.Println()
+
+		signer, err = ssh.ParsePrivateKeyWithPassphrase(key, bytePassword)
+		if err != nil {
+			return nil, noopCloseFunc, err
+		}
+	}
+
+	return ssh.PublicKeys(signer), noopCloseFunc, nil
+}

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -14,7 +14,7 @@ import (
 func MakeRemove() *cobra.Command {
 	var command = &cobra.Command{
 		Use:          "remove",
-	k	Short:        "remove k3s",
+		Short:        "remove k3s",
 		Long:         `remove k3s.`,
 		Example:      `  k3sup remove --ip 192.168.0.100 --user ubuntu`,
 		SilenceUsage: true,

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -47,7 +47,7 @@ func MakeUninstall() *cobra.Command {
 			sudoPrefix = "sudo "
 		}
 
-		uninstallK3scommand := fmt.Sprintf(sudoPrefix + "/usr/local/bin/k3s-killall.sh && " + sudoPrefix + "/usr/local/bin/k3s-uninstall.sh")
+		uninstallK3scommand := fmt.Sprintf(sudoPrefix + "/usr/local/bin/k3s-uninstall.sh")
 		if local {
 			operator := operator.ExecOperator{}
 

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -11,12 +11,12 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func MakeUninstall() *cobra.Command {
+func MakeRemove() *cobra.Command {
 	var command = &cobra.Command{
-		Use:          "uninstall",
-		Short:        "Uninstall k3s",
-		Long:         `Uninstall k3s.`,
-		Example:      `  k3sup uninstall --ip 192.168.0.100 --user ubuntu`,
+		Use:          "remove",
+	k	Short:        "remove k3s",
+		Long:         `remove k3s.`,
+		Example:      `  k3sup remove --ip 192.168.0.100 --user ubuntu`,
 		SilenceUsage: true,
 	}
 	command.Flags().IP("ip", net.ParseIP("127.0.0.1"), "Public IP of node")
@@ -29,7 +29,7 @@ func MakeUninstall() *cobra.Command {
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 
-		fmt.Printf("Running: k3sup uninstall\n")
+		fmt.Printf("Running: k3sup remove\n")
 
 		local, _ := command.Flags().GetBool("local")
 
@@ -41,13 +41,13 @@ func MakeUninstall() *cobra.Command {
 			sudoPrefix = "sudo "
 		}
 
-		uninstallK3scommand := fmt.Sprintf(sudoPrefix + "/usr/local/bin/k3s-uninstall.sh")
+		removeK3scommand := fmt.Sprintf(sudoPrefix + "/usr/local/bin/k3s-uninstall.sh")
 		if local {
 			operator := operator.ExecOperator{}
 
-			fmt.Printf("Executing: %s\n", uninstallK3scommand)
+			fmt.Printf("Executing: %s\n", removeK3scommand)
 
-			res, err := operator.Execute(uninstallK3scommand)
+			res, err := operator.Execute(removeK3scommand)
 			if err != nil {
 				return err
 			}
@@ -96,8 +96,8 @@ func MakeUninstall() *cobra.Command {
 
 		defer operator.Close()
 
-		fmt.Printf("ssh: %s\n", uninstallK3scommand)
-		res, err := operator.Execute(uninstallK3scommand)
+		fmt.Printf("ssh: %s\n", removeK3scommand)
+		res, err := operator.Execute(removeK3scommand)
 
 		if err != nil {
 			return fmt.Errorf("Error received processing command: %s", err)

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 
 	cmdInstall := cmd.MakeInstall()
-	cmdUninstall := cmd.MakeRemove()
+	cmdRemove := cmd.MakeRemove()
 	cmdVersion := cmd.MakeVersion()
 	cmdJoin := cmd.MakeJoin()
 	cmdApps := cmd.MakeApps()

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 
 	cmdInstall := cmd.MakeInstall()
-	cmdUninstall := cmd.MakeUninstall()
+	cmdUninstall := cmd.MakeRemove()
 	cmdVersion := cmd.MakeVersion()
 	cmdJoin := cmd.MakeJoin()
 	cmdApps := cmd.MakeApps()
@@ -26,7 +26,7 @@ func main() {
 	}
 
 	rootCmd.AddCommand(cmdInstall)
-	rootCmd.AddCommand(cmdUninstall)
+	rootCmd.AddCommand(cmdRemove)
 	rootCmd.AddCommand(cmdVersion)
 	rootCmd.AddCommand(cmdJoin)
 	rootCmd.AddCommand(cmdApps)

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 func main() {
 
 	cmdInstall := cmd.MakeInstall()
+	cmdUninstall := cmd.MakeUninstall()
 	cmdVersion := cmd.MakeVersion()
 	cmdJoin := cmd.MakeJoin()
 	cmdApps := cmd.MakeApps()
@@ -25,6 +26,7 @@ func main() {
 	}
 
 	rootCmd.AddCommand(cmdInstall)
+	rootCmd.AddCommand(cmdUninstall)
 	rootCmd.AddCommand(cmdVersion)
 	rootCmd.AddCommand(cmdJoin)
 	rootCmd.AddCommand(cmdApps)


### PR DESCRIPTION
Add built-in uninstall feature to k3sup 

## Description
- [x] uninstall command

## Motivation and Context
create an easier way to uninstall k3s server using k3sup 
#106 

## How Has This Been Tested?
<details>
  <summary>./k3sup uninstall</summary>

```
$ ./k3sup uninstall --local --user user                                                                                                                             ─╯
Running: k3sup uninstall
Executing: sudo /usr/local/bin/k3s-uninstall.sh
+ id -u
+ [ 0 -eq 0 ]
+ /usr/local/bin/k3s-killall.sh
+ [ -s /etc/systemd/system/k3s.service ]
+ basename /etc/systemd/system/k3s.service
+ systemctl stop k3s.service
+ [ -x /etc/init.d/k3s* ]
+ killtree 14706 14707 14708 14709
+ kill -9 14706 14946 15478 15529 14707 14953 15351 14708 14955 15287 14709 14935 15169
+ do_unmount /run/k3s
+ umount /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/ce01d6e04613644b5cd626c25fbca865cb17dfb52d40cecc5d15ba39381c0e24/rootfs /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/a36b69aa8610855ee9bb7b715c8f4d18fc44218ee6ab07a9d46819f11c1974ee/rootfs /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/7461a405ba5d154340c1db8ea9b0e4f4fb586f0587f79fa2ab7049f1ee9133f3/rootfs /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/57de2fd2aceb5f265214890f163c31530144c67f8bb56cf5bce80a6dbc093c25/rootfs /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/5233e51da70de6e766eefe821ad7e2aa2dc8e88131eae1a624107bba4e84ca4d/rootfs /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/3a819db1265807c1b25c80d538a5b8d8838e39e2def904adf7735bfb44d31187/rootfs /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/0d215c648408a3b40b9a72a5ea8856a3b88154ba04ff3b00e802e40749e2458f/rootfs /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/019cca43451cca25b458a284a715b4b94373b255594719bcb46000b893268835/rootfs /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/a36b69aa8610855ee9bb7b715c8f4d18fc44218ee6ab07a9d46819f11c1974ee/shm /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/7461a405ba5d154340c1db8ea9b0e4f4fb586f0587f79fa2ab7049f1ee9133f3/shm /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/5233e51da70de6e766eefe821ad7e2aa2dc8e88131eae1a624107bba4e84ca4d/shm /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/3a819db1265807c1b25c80d538a5b8d8838e39e2def904adf7735bfb44d31187/shm
+ do_unmount /var/lib/rancher/k3s
+ do_unmount /var/lib/kubelet/pods
+ umount /var/lib/kubelet/pods/d4f251b9-ab41-4597-b5fd-8f4d9310ced0/volumes/kubernetes.io~secret/metrics-server-token-hclbf /var/lib/kubelet/pods/733f5d86-ec67-4547-a063-5e65d09cec5a/volumes/kubernetes.io~secret/local-path-provisioner-service-account-token-9jlc9 /var/lib/kubelet/pods/26256b52-e1e4-4662-a0d7-a201f261ff78/volumes/kubernetes.io~secret/coredns-token-f6wq6 /var/lib/kubelet/pods/10ff2aee-e953-4155-a439-f17380b9e3ae/volumes/kubernetes.io~secret/helm-traefik-token-msdxx
+ do_unmount /run/netns/cni-
+ umount /run/netns/cni-d7f89e19-03bf-3e8a-dbce-230e719dfa74 /run/netns/cni-b5871a0e-1401-90ae-6b5a-ff6ee8b52e75 /run/netns/cni-b4382dca-32e1-924d-4ac1-c63c3e1d7a09 /run/netns/cni-2528fefe-9542-81ea-db0c-16b67db884a6
+ ip link show
+ grep master cni0
+ read ignore iface ignore
+ ip link delete cni0
+ ip link delete flannel.1
+ rm -rf /var/lib/cni/
+ + iptables-save
grep -v KUBE-
+ iptables-restore
+ grep -v CNI-
+ which systemctl
/usr/bin/systemctl
+ systemctl disable k3s
Removed /etc/systemd/system/multi-user.target.wants/k3s.service.
+ systemctl reset-failed k3s
+ systemctl daemon-reload
+ which rc-update
+ rm -f /etc/systemd/system/k3s.service
+ rm -f /etc/systemd/system/k3s.service.env
+ trap remove_uninstall EXIT
+ [ -L /usr/local/bin/kubectl ]
+ [ -L /usr/local/bin/crictl ]
+ rm -f /usr/local/bin/crictl
+ [ -L /usr/local/bin/ctr ]
+ rm -rf /etc/rancher/k3s
+ rm -rf /var/lib/rancher/k3s
+ rm -rf /var/lib/kubelet
+ rm -f /usr/local/bin/k3s
+ rm -f /usr/local/bin/k3s-killall.sh
+ remove_uninstall
+ rm -f /usr/local/bin/k3s-uninstall.sh
stderr: "+ id -u\n+ [ 0 -eq 0 ]\n+ /usr/local/bin/k3s-killall.sh\n+ [ -s /etc/systemd/system/k3s.service ]\n+ basename /etc/systemd/system/k3s.service\n+ systemctl stop k3s.service\n+ [ -x /etc/init.d/k3s* ]\n+ killtree 14706 14707 14708 14709\n+ kill -9 14706 14946 15478 15529 14707 14953 15351 14708 14955 15287 14709 14935 15169\n+ do_unmount /run/k3s\n+ umount /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/ce01d6e04613644b5cd626c25fbca865cb17dfb52d40cecc5d15ba39381c0e24/rootfs /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/a36b69aa8610855ee9bb7b715c8f4d18fc44218ee6ab07a9d46819f11c1974ee/rootfs /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/7461a405ba5d154340c1db8ea9b0e4f4fb586f0587f79fa2ab7049f1ee9133f3/rootfs /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/57de2fd2aceb5f265214890f163c31530144c67f8bb56cf5bce80a6dbc093c25/rootfs /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/5233e51da70de6e766eefe821ad7e2aa2dc8e88131eae1a624107bba4e84ca4d/rootfs /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/3a819db1265807c1b25c80d538a5b8d8838e39e2def904adf7735bfb44d31187/rootfs /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/0d215c648408a3b40b9a72a5ea8856a3b88154ba04ff3b00e802e40749e2458f/rootfs /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/019cca43451cca25b458a284a715b4b94373b255594719bcb46000b893268835/rootfs /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/a36b69aa8610855ee9bb7b715c8f4d18fc44218ee6ab07a9d46819f11c1974ee/shm /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/7461a405ba5d154340c1db8ea9b0e4f4fb586f0587f79fa2ab7049f1ee9133f3/shm /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/5233e51da70de6e766eefe821ad7e2aa2dc8e88131eae1a624107bba4e84ca4d/shm /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/3a819db1265807c1b25c80d538a5b8d8838e39e2def904adf7735bfb44d31187/shm\n+ do_unmount /var/lib/rancher/k3s\n+ do_unmount /var/lib/kubelet/pods\n+ umount /var/lib/kubelet/pods/d4f251b9-ab41-4597-b5fd-8f4d9310ced0/volumes/kubernetes.io~secret/metrics-server-token-hclbf /var/lib/kubelet/pods/733f5d86-ec67-4547-a063-5e65d09cec5a/volumes/kubernetes.io~secret/local-path-provisioner-service-account-token-9jlc9 /var/lib/kubelet/pods/26256b52-e1e4-4662-a0d7-a201f261ff78/volumes/kubernetes.io~secret/coredns-token-f6wq6 /var/lib/kubelet/pods/10ff2aee-e953-4155-a439-f17380b9e3ae/volumes/kubernetes.io~secret/helm-traefik-token-msdxx\n+ do_unmount /run/netns/cni-\n+ umount /run/netns/cni-d7f89e19-03bf-3e8a-dbce-230e719dfa74 /run/netns/cni-b5871a0e-1401-90ae-6b5a-ff6ee8b52e75 /run/netns/cni-b4382dca-32e1-924d-4ac1-c63c3e1d7a09 /run/netns/cni-2528fefe-9542-81ea-db0c-16b67db884a6\n+ ip link show\n+ grep master cni0\n+ read ignore iface ignore\n+ ip link delete cni0\n+ ip link delete flannel.1\n+ rm -rf /var/lib/cni/\n+ + iptables-save\ngrep -v KUBE-\n+ iptables-restore\n+ grep -v CNI-\n+ which systemctl\n+ systemctl disable k3s\nRemoved /etc/systemd/system/multi-user.target.wants/k3s.service.\n+ systemctl reset-failed k3s\n+ systemctl daemon-reload\n+ which rc-update\n+ rm -f /etc/systemd/system/k3s.service\n+ rm -f /etc/systemd/system/k3s.service.env\n+ trap remove_uninstall EXIT\n+ [ -L /usr/local/bin/kubectl ]\n+ [ -L /usr/local/bin/crictl ]\n+ rm -f /usr/local/bin/crictl\n+ [ -L /usr/local/bin/ctr ]\n+ rm -rf /etc/rancher/k3s\n+ rm -rf /var/lib/rancher/k3s\n+ rm -rf /var/lib/kubelet\n+ rm -f /usr/local/bin/k3s\n+ rm -f /usr/local/bin/k3s-killall.sh\n+ remove_uninstall\n+ rm -f /usr/local/bin/k3s-uninstall.sh\n"stdout: "/usr/bin/systemctl\n"

# check k3s file & process  
$ ps -e | grep k3s ; sudo find /usr/local/bin/ -type f -name "k3s*"                                                                                                                    ─╯
/usr/local/bin/k3sup
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
