### PR TITLE
Convert nginx-ingress and cert-manager to helm

### DIFF
--- a/cmd/apps/crossplane_app.go
+++ b/cmd/apps/crossplane_app.go
@@ -26,7 +26,7 @@ schedule workloads to any Kubernetes cluster`,
 
 	crossplane.Flags().StringP("namespace", "n", "crossplane-system", "The namespace used for installation")
 	crossplane.Flags().Bool("update-repo", true, "Update the helm repo")
-	crossplane.Flags().Bool("helm3", false, "Use helm3, if set to false uses helm2")
+	crossplane.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
 
 	crossplane.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()

--- a/cmd/apps/crossplane_app.go
+++ b/cmd/apps/crossplane_app.go
@@ -26,7 +26,7 @@ schedule workloads to any Kubernetes cluster`,
 
 	crossplane.Flags().StringP("namespace", "n", "crossplane-system", "The namespace used for installation")
 	crossplane.Flags().Bool("update-repo", true, "Update the helm repo")
-	crossplane.Flags().Bool("helm3", false, "Use helm3 instead of the default helm2")
+	crossplane.Flags().Bool("helm3", false, "Use helm3, if set to false uses helm2")
 
 	crossplane.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()

--- a/cmd/apps/inletsoperator_app.go
+++ b/cmd/apps/inletsoperator_app.go
@@ -34,7 +34,7 @@ func MakeInstallInletsOperator() *cobra.Command {
 	inletsOperator.Flags().Bool("update-repo", true, "Update the helm repo")
 
 	inletsOperator.Flags().String("pro-client-image", "", "Docker image for inlets-pro's client")
-	inletsOperator.Flags().Bool("helm3", true, "Use helm3 instead of the default helm2")
+	inletsOperator.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
 	inletsOperator.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set=image=org/repo:tag)")
 
 	inletsOperator.RunE = func(command *cobra.Command, args []string) error {

--- a/cmd/apps/inletsoperator_app.go
+++ b/cmd/apps/inletsoperator_app.go
@@ -34,7 +34,7 @@ func MakeInstallInletsOperator() *cobra.Command {
 	inletsOperator.Flags().Bool("update-repo", true, "Update the helm repo")
 
 	inletsOperator.Flags().String("pro-client-image", "", "Docker image for inlets-pro's client")
-	inletsOperator.Flags().Bool("helm3", false, "Use helm3 instead of the default helm2")
+	inletsOperator.Flags().Bool("helm3", true, "Use helm3 instead of the default helm2")
 	inletsOperator.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set=image=org/repo:tag)")
 
 	inletsOperator.RunE = func(command *cobra.Command, args []string) error {
@@ -51,6 +51,7 @@ func MakeInstallInletsOperator() *cobra.Command {
 		if helm3 {
 			fmt.Println("Using helm3")
 		}
+
 		namespace, _ := command.Flags().GetString("namespace")
 
 		if namespace != "default" {

--- a/cmd/apps/metricsserver_app.go
+++ b/cmd/apps/metricsserver_app.go
@@ -23,7 +23,7 @@ func MakeInstallMetricsServer() *cobra.Command {
 	}
 
 	metricsServer.Flags().StringP("namespace", "n", "kube-system", "The namespace used for installation")
-	metricsServer.Flags().Bool("helm3", false, "Use helm3 instead of the default helm2")
+	metricsServer.Flags().Bool("helm3", false, "Use helm3, if set to false uses helm2")
 
 	metricsServer.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()

--- a/cmd/apps/metricsserver_app.go
+++ b/cmd/apps/metricsserver_app.go
@@ -23,7 +23,7 @@ func MakeInstallMetricsServer() *cobra.Command {
 	}
 
 	metricsServer.Flags().StringP("namespace", "n", "kube-system", "The namespace used for installation")
-	metricsServer.Flags().Bool("helm3", false, "Use helm3, if set to false uses helm2")
+	metricsServer.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
 
 	metricsServer.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()

--- a/cmd/apps/nginx_app.go
+++ b/cmd/apps/nginx_app.go
@@ -25,7 +25,7 @@ func MakeInstallNginx() *cobra.Command {
 	nginx.Flags().StringP("namespace", "n", "default", "The namespace used for installation")
 	nginx.Flags().Bool("update-repo", true, "Update the helm repo")
 	nginx.Flags().Bool("host-mode", false, "If we should install nginx-ingress in host mode.")
-	nginx.Flags().Bool("helm3", true, "Use helm3 instead of the default helm2")
+	nginx.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
 
 	nginx.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()

--- a/cmd/apps/openfaas_app.go
+++ b/cmd/apps/openfaas_app.go
@@ -42,7 +42,7 @@ func MakeInstallOpenFaaS() *cobra.Command {
 	openfaas.Flags().Int("queue-workers", 1, "Replicas of queue-worker")
 	openfaas.Flags().Int("gateways", 1, "Replicas of gateway")
 
-	openfaas.Flags().Bool("helm3", false, "Use helm3, if set to false uses helm2")
+	openfaas.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
 
 	openfaas.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set=gateway.replicas=2)")
 

--- a/cmd/apps/openfaas_app.go
+++ b/cmd/apps/openfaas_app.go
@@ -42,7 +42,7 @@ func MakeInstallOpenFaaS() *cobra.Command {
 	openfaas.Flags().Int("queue-workers", 1, "Replicas of queue-worker")
 	openfaas.Flags().Int("gateways", 1, "Replicas of gateway")
 
-	openfaas.Flags().Bool("helm3", false, "Use helm3 instead of the default helm2")
+	openfaas.Flags().Bool("helm3", false, "Use helm3, if set to false uses helm2")
 
 	openfaas.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set=gateway.replicas=2)")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Convert nginx-ingress and cert-manager to helm

Adds and defaults `--helm3` flag.

## Motivation and Context

Part of #107 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by installing to k3s on Civo with and without flag.
