### PR TITLE
Replace tab with spaces in yaml string

### DIFF
--- a/cmd/apps/registry_ingress_app.go
+++ b/cmd/apps/registry_ingress_app.go
@@ -18,7 +18,7 @@ type RegInputData struct {
 	CertmanagerEmail string
 	IngressClass     string
 	Namespace        string
-	MaxSize          string
+	NginxMaxBuffer	 string
 }
 
 func MakeInstallRegistryIngress() *cobra.Command {
@@ -105,7 +105,11 @@ func buildRegistryYAML(domain, email, ingressClass, namespace, maxSize string) (
 		CertmanagerEmail: email,
 		IngressClass:     ingressClass,
 		Namespace:        namespace,
-		MaxSize:          maxSize,
+		NginxMaxBuffer:   "",
+	}
+
+	if ingressClass == "nginx" {
+		inputData.NginxMaxBuffer = fmt.Sprintf("    nginx.ingress.kubernetes.io/proxy-body-size: %s", maxSize)
 	}
 
 	var tpl bytes.Buffer
@@ -156,7 +160,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod-registry
     kubernetes.io/ingress.class: {{.IngressClass}}
-	nginx.ingress.kubernetes.io/proxy-body-size: {{.MaxSize}}
+{{.NginxMaxBuffer}}
 spec:
   rules:
   - host: {{.IngressDomain}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There was a rogue tab in the yaml string for the docker-registry-ingress causing issues

This has been replaces with 4 spaces and I have run through the installation again, using k3d,
inlets-operator, docker-registry and nginx-ingress.

The yaml was applied successfully. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.