### PR TITLE
Pass flag for helm version rather than use env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,10 +439,6 @@ Related tools:
 
 Currently there is an issue in k3s involving `iptables >= 1.8` that can affect the network communication. See the [k3s issue](https://github.com/rancher/k3s/issues/703) and the corresponding [kubernetes one](https://github.com/kubernetes/kubernetes/issues/71305) for more information and workarounds. The issue has been observed in Debian Buster but it can affect other distributions as well.
 
-### Custom helm versions
-
-Custom helm versions can be used with `k3sup app install`, if you set the environment variable `HELM_VERSION`
-
 ### Go modules
 
 * [Go modules wiki](https://github.com/golang/go/wiki/Modules)

--- a/cmd/apps/crossplane_app.go
+++ b/cmd/apps/crossplane_app.go
@@ -67,9 +67,6 @@ schedule workloads to any Kubernetes cluster`,
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		if helm3 {
-			os.Setenv("HELM_VERSION", helm3Version)
-		}
 		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, helm3)
 		if err != nil {
 			return err

--- a/cmd/apps/inletsoperator_app.go
+++ b/cmd/apps/inletsoperator_app.go
@@ -74,9 +74,6 @@ func MakeInstallInletsOperator() *cobra.Command {
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		if helm3 {
-			os.Setenv("HELM_VERSION", helm3Version)
-		}
 		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, helm3)
 		if err != nil {
 			return err

--- a/cmd/apps/istio_app.go
+++ b/cmd/apps/istio_app.go
@@ -61,9 +61,6 @@ func MakeInstallIstio() *cobra.Command {
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
 		helm3 := true
-		if helm3 {
-			os.Setenv("HELM_VERSION", helm3Version)
-		}
 
 		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, helm3)
 		if err != nil {

--- a/cmd/apps/metricsserver_app.go
+++ b/cmd/apps/metricsserver_app.go
@@ -55,9 +55,6 @@ func MakeInstallMetricsServer() *cobra.Command {
 		log.Printf("User dir established as: %s\n", userPath)
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		if helm3 {
-			os.Setenv("HELM_VERSION", helm3Version)
-		}
 
 		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, helm3)
 		if err != nil {

--- a/cmd/apps/mongodb_app.go
+++ b/cmd/apps/mongodb_app.go
@@ -52,7 +52,6 @@ func MakeInstallMongoDB() *cobra.Command {
 		log.Printf("User dir established as: %s\n", userPath)
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
-		os.Setenv("HELM_VERSION", helm3Version)
 
 		helm3 := true
 

--- a/cmd/apps/openfaas_app.go
+++ b/cmd/apps/openfaas_app.go
@@ -17,7 +17,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const helm3Version = "v3.0.2"
 
 func MakeInstallOpenFaaS() *cobra.Command {
 	var openfaas = &cobra.Command{
@@ -81,9 +80,6 @@ func MakeInstallOpenFaaS() *cobra.Command {
 		log.Printf("User dir established as: %s\n", userPath)
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		if helm3 {
-			os.Setenv("HELM_VERSION", helm3Version)
-		}
 
 		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, helm3)
 		if err != nil {

--- a/cmd/apps/registry_app.go
+++ b/cmd/apps/registry_app.go
@@ -43,11 +43,6 @@ func MakeInstallRegistry() *cobra.Command {
 		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 		helm3, _ := command.Flags().GetBool("helm3")
 
-		if helm3 {
-			fmt.Println("Using helm3")
-			os.Setenv("HELM_VERSION", helm3Version)
-		}
-
 		userPath, err := config.InitUserDir()
 		if err != nil {
 			return err

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -14,20 +14,19 @@ import (
 )
 
 const helmVersion = "v2.16.0"
+const helm3Version = "v3.0.2"
 
 func TryDownloadHelm(userPath, clientArch, clientOS string, helm3 bool) (string, error) {
 	helmVal := "helm"
+	subdir := ""
 	if helm3 {
 		helmVal = "helm3"
+		subdir = "helm3"
 	}
 
 	helmBinaryPath := path.Join(path.Join(userPath, "bin"), helmVal)
 	if _, statErr := os.Stat(helmBinaryPath); statErr != nil {
-		subdir := ""
-		if helm3 {
-			subdir = "helm3"
-		}
-		DownloadHelm(userPath, clientArch, clientOS, subdir)
+		DownloadHelm(userPath, clientArch, clientOS, subdir, helm3)
 
 		if !helm3 {
 			err := HelmInit()
@@ -52,8 +51,14 @@ func GetHelmURL(arch, os, version string) string {
 	return fmt.Sprintf("https://get.helm.sh/helm-%s-%s-%s.tar.gz", version, osSuffix, archSuffix)
 }
 
-func DownloadHelm(userPath, clientArch, clientOS, subdir string) error {
+func DownloadHelm(userPath, clientArch, clientOS, subdir string, helm3 bool) error {
+
 	useHelmVersion := helmVersion
+	if helm3 {
+		useHelmVersion = helm3Version
+	}
+
+	// This is an override users can set, its documented in the README
 	if val, ok := os.LookupEnv("HELM_VERSION"); ok && len(val) > 0 {
 		useHelmVersion = val
 	}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -58,11 +58,6 @@ func DownloadHelm(userPath, clientArch, clientOS, subdir string, helm3 bool) err
 		useHelmVersion = helm3Version
 	}
 
-	// This is an override users can set, its documented in the README
-	if val, ok := os.LookupEnv("HELM_VERSION"); ok && len(val) > 0 {
-		useHelmVersion = val
-	}
-
 	helmURL := GetHelmURL(clientArch, clientOS, useHelmVersion)
 	fmt.Println(helmURL)
 	parsedURL, _ := url.Parse(helmURL)


### PR DESCRIPTION
## Description
We were relying on each app setting an env var to
specify helm3 version, but if that wasn't set then
we installed helm2, and didn't try and init.
This left the user unable to use helm3 on any other
app too.

It has been changed to pass down a flag, then use that
flag in 1 place to decide what version to install.
Users can still override the version by setting an
env var, which is documented in the README.

This has been tested by rm -rf ing the ~/.k3sup
directory and installing using no flag, --helm3=false
, --helm3=true and --helm3

I have also overridden the version using the ENV Var

Fixes #195

<!--- Provide a general summary of your changes in the Title above -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#195


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using the flag, not using the flag and setting the env var for override. 
I deleted ~/.k3sup/ between each run

All worked with correct versions used now.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.