### PR TITLE
Allow Pinning of versions for charts

### DIFF
--- a/cmd/apps/certmanager_app.go
+++ b/cmd/apps/certmanager_app.go
@@ -107,20 +107,20 @@ func MakeInstallCertManager() *cobra.Command {
 
 		outputPath := path.Join(chartPath, "cert-manager/rendered")
 		overrides := map[string]string{}
-		wait := false
 
 		if helm3 {
 			outputPath := path.Join(chartPath, "cert-manager")
 
 			err := helm3Upgrade(outputPath, "jetstack/cert-manager", namespace,
 				"values.yaml",
-				overrides, wait)
+				"v0.12.0",
+				overrides)
 
 			if err != nil {
 				return err
 			}
 		} else {
-			err = templateChart(chartPath, "cert-manager", namespace, outputPath, "values.yaml", nil)
+			err = templateChart(chartPath, "cert-manager", namespace, outputPath, "values.yaml", "v0.12.0", nil)
 			if err != nil {
 				return err
 			}

--- a/cmd/apps/chart_app.go
+++ b/cmd/apps/chart_app.go
@@ -130,7 +130,7 @@ before using the generic helm chart installer command.`,
 			}
 		}
 
-		err = templateChart(chartPath, chartName, namespace, outputPath, "values.yaml", setMap)
+		err = templateChart(chartPath, chartName, namespace, outputPath, "values.yaml", "", setMap)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/cronconnector_app.go
+++ b/cmd/apps/cronconnector_app.go
@@ -105,6 +105,7 @@ func MakeInstallCronConnector() *cobra.Command {
 			ns,
 			outputPath,
 			"values.yaml",
+			"",
 			overrides)
 
 		if err != nil {

--- a/cmd/apps/crossplane_app.go
+++ b/cmd/apps/crossplane_app.go
@@ -97,7 +97,6 @@ schedule workloads to any Kubernetes cluster`,
 		}
 
 		if helm3 {
-			wait := false
 
 			outputPath := path.Join(chartPath, "crossplane")
 
@@ -107,14 +106,14 @@ schedule workloads to any Kubernetes cluster`,
 			}
 
 			err := helm3Upgrade(outputPath, "crossplane-alpha/crossplane",
-				namespace, "values.yaml", map[string]string{}, wait)
+				namespace, "values.yaml", "", map[string]string{})
 			if err != nil {
 				return err
 			}
 
 		} else {
 			outputPath := path.Join(chartPath, "crossplane-alpha/crossplane")
-			err = templateChart(chartPath, "crossplane", namespace, outputPath, "values.yaml", map[string]string{})
+			err = templateChart(chartPath, "crossplane", namespace, outputPath, "values.yaml", "", map[string]string{})
 			if err != nil {
 				return err
 			}

--- a/cmd/apps/inletsoperator_app.go
+++ b/cmd/apps/inletsoperator_app.go
@@ -149,19 +149,17 @@ func MakeInstallInletsOperator() *cobra.Command {
 		}
 
 		if helm3 {
-			wait := false
-
 			outputPath := path.Join(chartPath, "inlets-operator")
 
 			err := helm3Upgrade(outputPath, "inlets/inlets-operator",
-				namespace, "values.yaml", overrides, wait)
+				namespace, "values.yaml", "", overrides)
 			if err != nil {
 				return err
 			}
 
 		} else {
 			outputPath := path.Join(chartPath, "inlets-operator/rendered")
-			err = templateChart(chartPath, "inlets-operator", namespace, outputPath, "values.yaml", overrides)
+			err = templateChart(chartPath, "inlets-operator", namespace, outputPath, "values.yaml", "", overrides)
 			if err != nil {
 				return err
 			}

--- a/cmd/apps/istio_app.go
+++ b/cmd/apps/istio_app.go
@@ -115,10 +115,8 @@ func MakeInstallIstio() *cobra.Command {
 
 		outputPath := path.Join(chartPath, "istio")
 
-		wait := true
-
 		if initIstio, _ := command.Flags().GetBool("init"); initIstio {
-			err = helm3Upgrade(outputPath, "istio/istio-init", namespace, "", overrides, wait)
+			err = helm3Upgrade(outputPath, "istio/istio-init", namespace, "", "", overrides)
 			if err != nil {
 				return fmt.Errorf("unable to istio-init install chart with helm %s", err)
 			}
@@ -134,7 +132,7 @@ func MakeInstallIstio() *cobra.Command {
 			return err
 		}
 
-		err = helm3Upgrade(outputPath, "istio/istio", namespace, valuesFile, overrides, wait)
+		err = helm3Upgrade(outputPath, "istio/istio", namespace, valuesFile, "", overrides)
 		if err != nil {
 			return fmt.Errorf("unable to istio install chart with helm %s", err)
 		}

--- a/cmd/apps/kafkaconnector_app.go
+++ b/cmd/apps/kafkaconnector_app.go
@@ -122,6 +122,7 @@ func MakeInstallKafkaConnector() *cobra.Command {
 			ns,
 			outputPath,
 			"values.yaml",
+			"",
 			overrides)
 
 		if err != nil {

--- a/cmd/apps/kubernetes_exec.go
+++ b/cmd/apps/kubernetes_exec.go
@@ -49,7 +49,7 @@ func getNodeArchitecture() string {
 	return arch
 }
 
-func helm3Upgrade(basePath, chart, namespace, values string, overrides map[string]string, wait bool) error {
+func helm3Upgrade(basePath, chart, namespace, values, version string, overrides map[string]string) error {
 
 	chartName := chart
 	if index := strings.Index(chartName, "/"); index > -1 {
@@ -58,7 +58,13 @@ func helm3Upgrade(basePath, chart, namespace, values string, overrides map[strin
 
 	chartRoot := basePath
 
-	args := []string{"upgrade", "--install", chartName, chart, "--namespace", namespace}
+
+
+	args := []string{"upgrade", "--install", chartName, chart, "--namespace", namespace, }
+	if len(version) > 0 {
+		args = append(args, "--version", version)
+	}
+
 	fmt.Println("VALUES", values)
 	if len(values) > 0 {
 		args = append(args, "--values")
@@ -100,7 +106,7 @@ func helm3Upgrade(basePath, chart, namespace, values string, overrides map[strin
 	return nil
 }
 
-func templateChart(basePath, chart, namespace, outputPath, values string, overrides map[string]string) error {
+func templateChart(basePath, chart, namespace, outputPath, values, version string, overrides map[string]string) error {
 
 	rmErr := os.RemoveAll(outputPath)
 
@@ -125,9 +131,14 @@ func templateChart(basePath, chart, namespace, outputPath, values string, overri
 		valuesStr = "--values " + path.Join(chartRoot, values)
 	}
 
+	versionStr := ""
+	if len(version) > 0 {
+		versionStr = "--version " + version
+	}
+
 	task := execute.ExecTask{
-		Command: fmt.Sprintf("%s template %s --name %s --namespace %s --output-dir %s %s %s",
-			env.LocalBinary("helm", ""), chart, chart, namespace, outputPath, valuesStr, overridesStr),
+		Command: fmt.Sprintf("%s template %s --name %s --namespace %s --output-dir %s %s %s %s",
+			env.LocalBinary("helm", ""), chart, chart, namespace, outputPath, valuesStr, overridesStr, versionStr),
 		Env:         os.Environ(),
 		Cwd:         basePath,
 		StreamStdio: true,

--- a/cmd/apps/metricsserver_app.go
+++ b/cmd/apps/metricsserver_app.go
@@ -80,14 +80,13 @@ func MakeInstallMetricsServer() *cobra.Command {
 		overrides["args"] = `{--kubelet-insecure-tls,--kubelet-preferred-address-types=InternalIP\,ExternalIP\,Hostname}`
 		fmt.Println("Chart path: ", chartPath)
 
-		wait := false
-
 		if helm3 {
 			outputPath := path.Join(chartPath, "metrics-server")
 
 			err := helm3Upgrade(outputPath, "stable/metrics-server", namespace,
 				"values.yaml",
-				overrides, wait)
+				"",
+				overrides)
 
 			if err != nil {
 				return err
@@ -101,6 +100,7 @@ func MakeInstallMetricsServer() *cobra.Command {
 				namespace,
 				outputPath,
 				"values.yaml",
+				"",
 				overrides)
 
 			if err != nil {

--- a/cmd/apps/minio_app.go
+++ b/cmd/apps/minio_app.go
@@ -125,6 +125,7 @@ func MakeInstallMinio() *cobra.Command {
 			ns,
 			outputPath,
 			"values.yaml",
+			"",
 			overrides)
 
 		if err != nil {

--- a/cmd/apps/mongodb_app.go
+++ b/cmd/apps/mongodb_app.go
@@ -101,7 +101,7 @@ func MakeInstallMongoDB() *cobra.Command {
 		}
 
 		err = helm3Upgrade(outputPath, "stable/mongodb",
-			namespace, "values.yaml", overrides, false)
+			namespace, "values.yaml", "",overrides)
 		if err != nil {
 			return fmt.Errorf("unable to mongodb chart with helm %s", err)
 		}

--- a/cmd/apps/nginx_app.go
+++ b/cmd/apps/nginx_app.go
@@ -113,7 +113,6 @@ func MakeInstallNginx() *cobra.Command {
 		}
 		fmt.Println("Chart path: ", chartPath)
 
-		wait := false
 		ns := "default"
 
 		if helm3 {
@@ -121,7 +120,8 @@ func MakeInstallNginx() *cobra.Command {
 
 			err := helm3Upgrade(outputPath, "stable/nginx-ingress", ns,
 				"values.yaml",
-				overrides, wait)
+				"",
+				overrides)
 
 			if err != nil {
 				return err
@@ -134,6 +134,7 @@ func MakeInstallNginx() *cobra.Command {
 				ns,
 				outputPath,
 				"values.yaml",
+				"",
 				overrides)
 
 			if err != nil {

--- a/cmd/apps/openfaas_app.go
+++ b/cmd/apps/openfaas_app.go
@@ -199,13 +199,13 @@ func MakeInstallOpenFaaS() *cobra.Command {
 			return err
 		}
 
-		wait := false
 		if helm3 {
 			outputPath := path.Join(chartPath, "openfaas")
 
 			err := helm3Upgrade(outputPath, "openfaas/openfaas", namespace,
 				"values"+valuesSuffix+".yaml",
-				overrides, wait)
+				"",
+				overrides)
 
 			if err != nil {
 				return err
@@ -217,6 +217,7 @@ func MakeInstallOpenFaaS() *cobra.Command {
 				namespace,
 				outputPath,
 				"values"+valuesSuffix+".yaml",
+				"",
 				overrides)
 
 			if err != nil {

--- a/cmd/apps/postgres_app.go
+++ b/cmd/apps/postgres_app.go
@@ -105,6 +105,7 @@ func MakeInstallPostgresql() *cobra.Command {
 			ns,
 			outputPath,
 			"values.yaml",
+			"",
 			overrides)
 
 		if err != nil {

--- a/cmd/apps/registry_app.go
+++ b/cmd/apps/registry_app.go
@@ -119,7 +119,6 @@ func MakeInstallRegistry() *cobra.Command {
 
 		fmt.Println("Chart path: ", chartPath)
 
-		wait := false
 		ns := "default"
 
 		if helm3 {
@@ -127,7 +126,8 @@ func MakeInstallRegistry() *cobra.Command {
 
 			err := helm3Upgrade(outputPath, "stable/docker-registry", ns,
 				"values.yaml",
-				overrides, wait)
+				"",
+				overrides)
 
 			if err != nil {
 				return err
@@ -140,6 +140,7 @@ func MakeInstallRegistry() *cobra.Command {
 				ns,
 				outputPath,
 				"values.yaml",
+				"",
 				overrides)
 
 			if err != nil {


### PR DESCRIPTION
## Description
We have had a case where cert-manager upgraded and we
had pinned the CRD to v0.12.0, we installed the
latest chart by default so we have 0.12.0 CRD and
0.13.0 chart. This caused issues.

We can now optionally pin a helm chart version.


Fixes #199

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#199

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Installed cert-manager (which now has pinned v0.12.0) and it installed that version
Installed OpenFaaS (no pinned version) and it installed latest


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.