### PR TITLE
Add flag to override basic-auth password

### DIFF
--- a/cmd/apps/openfaas_app.go
+++ b/cmd/apps/openfaas_app.go
@@ -28,6 +28,7 @@ func MakeInstallOpenFaaS() *cobra.Command {
 	}
 
 	openfaas.Flags().BoolP("basic-auth", "a", true, "Enable authentication")
+	openfaas.Flags().String("basic-auth-password", "", "Overide the default random basic-auth-password if this is set")
 	openfaas.Flags().BoolP("load-balancer", "l", false, "Add a loadbalancer")
 	openfaas.Flags().StringP("namespace", "n", "openfaas", "The namespace for the core services")
 	openfaas.Flags().Bool("update-repo", true, "Update the helm repo")
@@ -111,9 +112,14 @@ func MakeInstallOpenFaaS() *cobra.Command {
 			return err
 		}
 
-		pass, err := password.Generate(25, 10, 0, false, true)
-		if err != nil {
-			return err
+		pass, _ := command.Flags().GetString("basic-auth-password")
+
+		if len(pass) == 0 {
+			var err error
+			pass, err = password.Generate(25, 10, 0, false, true)
+			if err != nil {
+				return err
+			}
 		}
 
 		res, secretErr := kubectlTask("-n", namespace, "create", "secret", "generic",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This adds a flag to the openfaas app that overides
the randomly generated password with a customer-supplied
value

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested by setting the flag, and reading the value from kubectl secret
Also I was able to login to the UI.

Then I left the flag off, and a random password was generated, and I used this to login



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
closes #206


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.