### PR TITLE
Rework the wait flag to be optional and fix chart template

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,3 +446,11 @@ Currently there is an issue in k3s involving `iptables >= 1.8` that can affect t
 
 * [Go modules wiki](https://github.com/golang/go/wiki/Modules)
 
+
+### Troubleshooting
+
+There was an odd edge case in one of the previous versions, If you are having error with helm throwing an
+error about tiller not being ready then you might want to remove the `~/.k3sup/` directory, which holds some
+info used by `k3sup`. Once you have removed this you should try again.
+
+If you are having any other issues or have questions please open an issue.

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -33,6 +33,7 @@ command.`,
 	}
 
 	install.PersistentFlags().String("kubeconfig", "kubeconfig", "Local path for your kubeconfig file")
+	install.PersistentFlags().Bool("wait", false, "If we should wait for the resource to be ready before returning (helm3 only, default false)")
 
 	install.RunE = func(command *cobra.Command, args []string) error {
 

--- a/cmd/apps/certmanager_app.go
+++ b/cmd/apps/certmanager_app.go
@@ -27,6 +27,7 @@ func MakeInstallCertManager() *cobra.Command {
 	certManager.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
 
 	certManager.RunE = func(command *cobra.Command, args []string) error {
+		wait, _ := command.Flags().GetBool("wait")
 		const certManagerVersion = "v0.12.0"
 		kubeConfigPath := getDefaultKubeconfig()
 
@@ -115,7 +116,8 @@ func MakeInstallCertManager() *cobra.Command {
 			err := helm3Upgrade(outputPath, "jetstack/cert-manager", namespace,
 				"values.yaml",
 				"v0.12.0",
-				overrides)
+				overrides,
+				wait)
 
 			if err != nil {
 				return err

--- a/cmd/apps/crossplane_app.go
+++ b/cmd/apps/crossplane_app.go
@@ -29,6 +29,7 @@ schedule workloads to any Kubernetes cluster`,
 	crossplane.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
 
 	crossplane.RunE = func(command *cobra.Command, args []string) error {
+		wait, _ := command.Flags().GetBool("wait")
 		kubeConfigPath := getDefaultKubeconfig()
 
 		if command.Flags().Changed("kubeconfig") {
@@ -103,7 +104,7 @@ schedule workloads to any Kubernetes cluster`,
 			}
 
 			err := helm3Upgrade(outputPath, "crossplane-alpha/crossplane",
-				namespace, "values.yaml", "", map[string]string{})
+				namespace, "values.yaml", "", map[string]string{}, wait)
 			if err != nil {
 				return err
 			}

--- a/cmd/apps/inletsoperator_app.go
+++ b/cmd/apps/inletsoperator_app.go
@@ -40,6 +40,7 @@ func MakeInstallInletsOperator() *cobra.Command {
 	inletsOperator.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
 
+		wait, _ := command.Flags().GetBool("wait")
 		if command.Flags().Changed("kubeconfig") {
 			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
 		}
@@ -149,7 +150,7 @@ func MakeInstallInletsOperator() *cobra.Command {
 			outputPath := path.Join(chartPath, "inlets-operator")
 
 			err := helm3Upgrade(outputPath, "inlets/inlets-operator",
-				namespace, "values.yaml", "", overrides)
+				namespace, "values.yaml", "", overrides, wait)
 			if err != nil {
 				return err
 			}

--- a/cmd/apps/istio_app.go
+++ b/cmd/apps/istio_app.go
@@ -33,6 +33,7 @@ func MakeInstallIstio() *cobra.Command {
 
 	istio.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
+		wait, _ := command.Flags().GetBool("wait")
 
 		if command.Flags().Changed("kubeconfig") {
 			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
@@ -113,7 +114,7 @@ func MakeInstallIstio() *cobra.Command {
 		outputPath := path.Join(chartPath, "istio")
 
 		if initIstio, _ := command.Flags().GetBool("init"); initIstio {
-			err = helm3Upgrade(outputPath, "istio/istio-init", namespace, "", "", overrides)
+			err = helm3Upgrade(outputPath, "istio/istio-init", namespace, "", defaultVersion, overrides, wait)
 			if err != nil {
 				return fmt.Errorf("unable to istio-init install chart with helm %s", err)
 			}
@@ -129,7 +130,7 @@ func MakeInstallIstio() *cobra.Command {
 			return err
 		}
 
-		err = helm3Upgrade(outputPath, "istio/istio", namespace, valuesFile, "", overrides)
+		err = helm3Upgrade(outputPath, "istio/istio", namespace, valuesFile, defaultVersion, overrides, wait)
 		if err != nil {
 			return fmt.Errorf("unable to istio install chart with helm %s", err)
 		}

--- a/cmd/apps/metricsserver_app.go
+++ b/cmd/apps/metricsserver_app.go
@@ -26,6 +26,7 @@ func MakeInstallMetricsServer() *cobra.Command {
 	metricsServer.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
 
 	metricsServer.RunE = func(command *cobra.Command, args []string) error {
+		wait, _ := command.Flags().GetBool("wait")
 		kubeConfigPath := getDefaultKubeconfig()
 
 		if command.Flags().Changed("kubeconfig") {
@@ -82,8 +83,9 @@ func MakeInstallMetricsServer() *cobra.Command {
 
 			err := helm3Upgrade(outputPath, "stable/metrics-server", namespace,
 				"values.yaml",
-				"",
-				overrides)
+				defaultVersion,
+				overrides,
+				wait)
 
 			if err != nil {
 				return err

--- a/cmd/apps/mongodb_app.go
+++ b/cmd/apps/mongodb_app.go
@@ -30,6 +30,7 @@ func MakeInstallMongoDB() *cobra.Command {
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 
+		wait, _ := command.Flags().GetBool("wait")
 		kubeConfigPath := getDefaultKubeconfig()
 
 		if command.Flags().Changed("kubeconfig") {
@@ -100,7 +101,7 @@ func MakeInstallMongoDB() *cobra.Command {
 		}
 
 		err = helm3Upgrade(outputPath, "stable/mongodb",
-			namespace, "values.yaml", "",overrides)
+			namespace, "values.yaml", defaultVersion,overrides, wait)
 		if err != nil {
 			return fmt.Errorf("unable to mongodb chart with helm %s", err)
 		}

--- a/cmd/apps/nginx_app.go
+++ b/cmd/apps/nginx_app.go
@@ -29,6 +29,7 @@ func MakeInstallNginx() *cobra.Command {
 
 	nginx.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
+		wait, _ := command.Flags().GetBool("wait")
 
 		if command.Flags().Changed("kubeconfig") {
 			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
@@ -120,8 +121,9 @@ func MakeInstallNginx() *cobra.Command {
 
 			err := helm3Upgrade(outputPath, "stable/nginx-ingress", ns,
 				"values.yaml",
-				"",
-				overrides)
+				defaultVersion,
+				overrides,
+				wait)
 
 			if err != nil {
 				return err

--- a/cmd/apps/openfaas_app.go
+++ b/cmd/apps/openfaas_app.go
@@ -49,7 +49,7 @@ func MakeInstallOpenFaaS() *cobra.Command {
 
 	openfaas.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
-
+		wait, _ := command.Flags().GetBool("wait")
 		if command.Flags().Changed("kubeconfig") {
 			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
 		}
@@ -138,8 +138,9 @@ func MakeInstallOpenFaaS() *cobra.Command {
 
 		chartPath := path.Join(os.TempDir(), "charts")
 
+		println("foo")
 		err = fetchChart(chartPath, "openfaas/openfaas", defaultVersion, helm3)
-
+		println("foo")
 		if err != nil {
 			return err
 		}
@@ -208,7 +209,8 @@ func MakeInstallOpenFaaS() *cobra.Command {
 			err := helm3Upgrade(outputPath, "openfaas/openfaas", namespace,
 				"values"+valuesSuffix+".yaml",
 				"",
-				overrides)
+				overrides,
+				wait)
 
 			if err != nil {
 				return err

--- a/cmd/apps/registry_app.go
+++ b/cmd/apps/registry_app.go
@@ -33,6 +33,7 @@ func MakeInstallRegistry() *cobra.Command {
 
 	registry.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
+		wait, _ := command.Flags().GetBool("wait")
 
 		if command.Flags().Changed("kubeconfig") {
 			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
@@ -122,7 +123,8 @@ func MakeInstallRegistry() *cobra.Command {
 			err := helm3Upgrade(outputPath, "stable/docker-registry", ns,
 				"values.yaml",
 				defaultVersion,
-				overrides)
+				overrides,
+				wait)
 
 			if err != nil {
 				return err


### PR DESCRIPTION
## Description

We have added back the ability to make --wait optional, and use it.
There is also an issue in helm template where an extra space gets
seen as a new chart to pull and errors on " " not being a valid chart

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
re-add functionality

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
new k3d cluster between each run

chart with no version pinning:
go build && ./k3sup app install openfaas
go build && ./k3sup app install openfaas --wait

chart with version pinning:
go build && ./k3sup app install cert-manager
go build && ./k3sup app install cert-manager --wait

--wait blocked until the release was ready, no wait returned without waiting.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
