### PR TITLE
Update inlets-operator app overrides

### DIFF
--- a/cmd/apps/inletsoperator_app.go
+++ b/cmd/apps/inletsoperator_app.go
@@ -202,7 +202,7 @@ func getInletsOperatorOverrides(command *cobra.Command) (map[string]string, erro
 		if err != nil {
 			return overrides, err
 		}
-		overrides["gceProjectId"] = gceProjectID
+		overrides["projectID"] = gceProjectID
 
 		zone, err := command.Flags().GetString("zone")
 		if err != nil {
@@ -222,7 +222,7 @@ func getInletsOperatorOverrides(command *cobra.Command) (map[string]string, erro
 		if err != nil {
 			return overrides, err
 		}
-		overrides["packetProjectId"] = packetProjectID
+		overrides["projectID"] = packetProjectID
 
 		if len(packetProjectID) == 0 {
 			return overrides, fmt.Errorf("project-id is required for provider %s", provider)
@@ -233,7 +233,7 @@ func getInletsOperatorOverrides(command *cobra.Command) (map[string]string, erro
 		if err != nil {
 			return overrides, err
 		}
-		overrides["organization-id"] = orgID
+		overrides["organizationID"] = orgID
 
 		if len(orgID) == 0 {
 			return overrides, fmt.Errorf("organization-id is required for provider %s", provider)


### PR DESCRIPTION
Update inlets-operator app overrides
Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update the inlets-op overrides to use `projectID` instead of
`gceProjectID` and `packetProjectID`.
Also use `organizationID` instead of `organization-id` in overrides
as helm does not accept "-" in the key passed into the --set flag.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
