### PR TITLE
Add tests for thrown errors upon project-id omission

### DIFF
--- a/cmd/apps/inletsoperator_app_test.go
+++ b/cmd/apps/inletsoperator_app_test.go
@@ -1,0 +1,34 @@
+package apps
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_throwErrorForProjectIdOmission(t *testing.T) {
+	projectID := ""
+	providers := []string{"gce", "packet"}
+	zone := "us-central1-a"
+
+	cmd := MakeInstallInletsOperator()
+
+	for _, provider := range providers {
+		err := cmd.Flags().Set("provider", provider)
+		if err != nil {
+			t.Errorf("cannot set value of flag provider: %v", err)
+		}
+		err = cmd.Flags().Set("zone", zone)
+		if err != nil {
+			t.Errorf("cannot set value of flag zone: %v", err)
+		}
+		cmd.Flags().Set("project-id", projectID)
+		if err != nil {
+			t.Errorf("cannot set value of flag project-id: %v", err)
+		}
+		_, err = getInletsOperatorOverrides(cmd)
+
+		if len(fmt.Sprint(err)) == 0 {
+			t.Errorf("no error thrown on omitted project-id flag for provider %s", provider)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #186

Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds tests to check if we throw an error when the `project-id` flag is not set when using a provider that requires it like `gce` or `packet`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
