### PR TITLE
Version bump to v1.17.3+k3s1

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 // K3sVersion default version
-const K3sVersion = "v1.17.2+k3s1"
+const K3sVersion = "v1.17.3+k3s1"
 
 func InitUserDir() (string, error) {
 	home := os.Getenv("HOME")


### PR DESCRIPTION
Version bump to v1.17.3

I do not have rpi's to test it on, I do however have a 5 node cluster running with this version of k3s, 4 HA masters and an agent.

Feel free to accept PR when someone else has been able to test on rPi
