### PR TITLE
Fixes #228 support downloading into a folder with a space

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -98,14 +98,14 @@ getPackage() {
         targetFile="$(pwd)/$REPO$suffix"
     fi
 
-    if [ -e $targetFile ]; then
-        rm $targetFile
+    if [ -e "$targetFile" ]; then
+        rm "$targetFile"
     fi
 
     url=https://github.com/$OWNER/$REPO/releases/download/$version/$REPO$suffix
     echo "Downloading package $url as $targetFile"
 
-    curl -sSL $url --output $targetFile
+    curl -sSL $url --output "$targetFile"
 
     if [ "$?" = "0" ]; then
 
@@ -113,7 +113,7 @@ getPackage() {
             checkHash
         fi
 
-    chmod +x $targetFile
+    chmod +x "$targetFile"
 
     echo "Download complete."
        
@@ -158,8 +158,8 @@ getPackage() {
                 echo "New version of $REPO installed to $BINLOCATION"
             fi
 
-            if [ -e $targetFile ]; then
-                rm $targetFile
+            if [ -e "$targetFile" ]; then
+                rm "$targetFile"
             fi
 
             if [ -n "$ALIAS_NAME" ]; then


### PR DESCRIPTION
This commit will solve issue #228 which will add support for downloading into a folder with space.

Signed-off-by: Amal Alkhamees <amalkms5@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
$ pwd
/Users/amal/go/src/github.com/k3sup/test k3sup
$ ../get.sh
Downloading package https://github.com/alexellis/k3sup/releases/download/0.9.2/k3sup-darwin as /Users/amal/go/src/github.com/k3sup/test k3sup/k3sup-darwin
Download complete.

Running with sufficient permissions to attempt to move k3sup to /usr/local/bin
usage: mv [-f | -i | -n] [-v] source target
       mv [-f | -i | -n] [-v] source ... directory
../get.sh: line 161: [: /Users/amal/go/src/github.com/k3sup/test: binary operator expected
 _    _____                 
| | _|___ / ___ _   _ _ __  
| |/ / |_ \/ __| | | | '_ \ 
|   < ___) \__ \ |_| | |_) |
|_|\_\____/|___/\__,_| .__/ 
                     |_|    
Version: 0.9.2

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
