### PR TITLE
Use k3s branch feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,8 @@ MIT
 
 * [Kubernetes: from Zero to Hero with Kompose, Minikube, k3sup and Helm](https://blog.mi.hdm-stuttgart.de/index.php/2020/02/29/image-editor-on-kubernetes-with-kompose-minikube-k3s-k3sup-and-helm-part-2/) by Leon Klingele, Alexander Merker & Florian Wintel
 
+* [Deploying a highly-available K3s with k3sup](https://ma.ttias.be/deploying-highly-available-k3s-k3sup/) by Dmitriy Akulov
+
 Checkout the [Announcement tweet](https://twitter.com/alexellisuk/status/1162272786250735618?s=20)
 
 ## Similar tools & glossary

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -47,7 +47,8 @@ func MakeInstall() *cobra.Command {
 	command.Flags().Bool("ipsec", false, "Enforces and/or activates optional extra argument for k3s: flannel-backend option: ipsec")
 	command.Flags().Bool("merge", false, `Merge the config with existing kubeconfig if it already exists.
 Provide the --local-path flag with --merge if a kubeconfig already exists in some other directory`)
-	command.Flags().String("k3s-version", config.K3sVersion, "Optional version to install, pinned at a default")
+	command.Flags().String("k3s-version", "", "Optional version to install")
+	command.Flags().String("k3s-branch", config.K3sBranch, "Optional branch to install from, pinned at stable")
 
 	command.Flags().Bool("local", false, "Perform a local install without using ssh")
 	command.Flags().Bool("cluster", false, "Form a dqlite cluster")
@@ -67,6 +68,7 @@ Provide the --local-path flag with --merge if a kubeconfig already exists in som
 		}
 
 		k3sVersion, _ := command.Flags().GetString("k3s-version")
+		k3sBranch, _ := command.Flags().GetString("k3s-branch")
 		k3sExtraArgs, _ := command.Flags().GetString("k3s-extra-args")
 		k3sNoExtras, _ := command.Flags().GetBool("no-extras")
 
@@ -90,9 +92,18 @@ Provide the --local-path flag with --merge if a kubeconfig already exists in som
 			k3sExtraArgs += `--no-deploy servicelb --no-deploy traefik`
 		}
 
+		var k3sVersionCmd string
+
+		if k3sVersion != "" {
+			k3sVersionCmd = fmt.Sprintf("INSTALL_K3S_VERSION='%s'",k3sVersion)
+		} else {
+			k3sVersionCmd = fmt.Sprintf("INSTALL_K3S_CHANNEL='%s'",k3sBranch)
+		}
+
 		installk3sExec := fmt.Sprintf("INSTALL_K3S_EXEC='server %s --tls-san %s %s'", clusterStr, ip, strings.TrimSpace(k3sExtraArgs))
 
-		installK3scommand := fmt.Sprintf("curl -sLS https://get.k3s.io | %s INSTALL_K3S_VERSION='%s' sh -\n", installk3sExec, k3sVersion)
+		
+		installK3scommand := fmt.Sprintf("curl -sLS https://get.k3s.io | %s %s sh -\n", installk3sExec, k3sVersionCmd)
 		getConfigcommand := fmt.Sprintf(sudoPrefix + "cat /etc/rancher/k3s/k3s.yaml\n")
 		merge, _ := command.Flags().GetBool("merge")
 		context, _ := command.Flags().GetString("context")
@@ -327,6 +338,10 @@ func loadPublickey(path string) (ssh.AuthMethod, func() error, error) {
 
 		fmt.Printf("Enter passphrase for '%s': ", path)
 		bytePassword, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+		if err != nil {
+			return nil, noopCloseFunc, err
+		}
+
 		fmt.Println()
 
 		signer, err = ssh.ParsePrivateKeyWithPassphrase(key, bytePassword)

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -33,7 +33,8 @@ func MakeJoin() *cobra.Command {
 	command.Flags().Bool("skip-install", false, "Skip the k3s installer")
 	command.Flags().Bool("sudo", true, "Use sudo for installation. e.g. set to false when using the root user and no sudo is available.")
 	command.Flags().String("k3s-extra-args", "", "Optional extra arguments to pass to k3s installer, wrapped in quotes (e.g. --k3s-extra-args '--node-taint key=value:NoExecute')")
-	command.Flags().String("k3s-version", config.K3sVersion, "Optional version to install, pinned at a default")
+	command.Flags().String("k3s-version", "", "Optional version to install, pinned at a default")
+	command.Flags().String("k3s-branch", config.K3sBranch, "Optional branch to install from, pinned at stable")
 
 	command.Flags().Bool("server", false, "Join the cluster as a server rather than as an agent")
 
@@ -67,6 +68,15 @@ func MakeJoin() *cobra.Command {
 
 		k3sExtraArgs, _ := command.Flags().GetString("k3s-extra-args")
 		k3sVersion, _ := command.Flags().GetString("k3s-version")
+		k3sBranch, _ := command.Flags().GetString("k3s-branch")
+
+		var k3sVersionCmd string
+
+		if k3sVersion != "" {
+			k3sVersionCmd = fmt.Sprintf("INSTALL_K3S_VERSION='%s'",k3sVersion)
+		} else {
+			k3sVersionCmd = fmt.Sprintf("INSTALL_K3S_CHANNEL='%s'",k3sBranch)
+		}
 
 		useSudo, _ := command.Flags().GetBool("sudo")
 		sudoPrefix := ""
@@ -121,9 +131,9 @@ func MakeJoin() *cobra.Command {
 
 		var boostrapErr error
 		if server {
-			boostrapErr = setupAdditionalServer(serverIP, ip, port, user, sshKeyPath, joinToken, k3sExtraArgs, k3sVersion)
+			boostrapErr = setupAdditionalServer(serverIP, ip, port, user, sshKeyPath, joinToken, k3sExtraArgs, k3sVersionCmd)
 		} else {
-			boostrapErr = setupAgent(serverIP, ip, port, user, sshKeyPath, joinToken, k3sExtraArgs, k3sVersion)
+			boostrapErr = setupAgent(serverIP, ip, port, user, sshKeyPath, joinToken, k3sExtraArgs, k3sVersionCmd)
 		}
 
 		return boostrapErr

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,8 +6,8 @@ import (
 	"path"
 )
 
-// K3sVersion default version
-const K3sVersion = "v1.17.2+k3s1"
+// K3sBranch default branch
+const K3sBranch = "stable"
 
 func InitUserDir() (string, error) {
 	home := os.Getenv("HOME")


### PR DESCRIPTION
Sorry messed up my first pr.

## Description
K3s provides branches, which makes it possible to update the release without update of k3sup or overwritting the version flag.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For me it makes it much simpler to keep my cluster at the stable version without need for a wrapper script

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've run the command 3 times against one of my nodes 
* without anything, then it will lookup the current stable version
* with testing as branch provided, then it will lookup the current testing version
* with version 1.17.4 provided, then it will lookup the specific version

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
Instead of pinning to a version we now pin to a branch

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.