### PR TITLE
add remove command

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"fmt"
+	"net"
+
+	operator "github.com/alexellis/k3sup/pkg/operator"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh"
+)
+
+func MakeRemove() *cobra.Command {
+	var command = &cobra.Command{
+		Use:          "remove",
+		Short:        "Remove k3s on a server via SSH",
+		Long:         `Remove k3s on a server via SSH.`,
+		Example:      `k3sup remove --ip 192.168.0.100 --user root`,
+		SilenceUsage: true,
+	}
+
+	command.Flags().IP("ip", net.ParseIP("127.0.0.1"), "Public IP of node")
+	command.Flags().String("user", "root", "Username for SSH login")
+	command.Flags().String("ssh-key", "~/.ssh/id_rsa", "The ssh key to use for remote login")
+	command.Flags().Int("ssh-port", 22, "The port on which to connect for ssh")
+	command.Flags().Bool("sudo", true, "Use sudo for uninstallation. e.g. set to false when using the root user and no sudo is available.")
+	command.Flags().Bool("local", false, "Perform a local uninstall without using ssh")
+
+	command.RunE = func(command *cobra.Command, args []string) error {
+		fmt.Printf("Running: k3sup remove\n")
+
+		local, _ := command.Flags().GetBool("local")
+		ip, _ := command.Flags().GetIP("ip")
+
+		removeK3scommand := " sh /usr/local/bin/k3s-uninstall.sh"
+		if local {
+			operator := operator.ExecOperator{}
+
+			fmt.Printf("Executing: %s\n", removeK3scommand)
+
+			res, err := operator.Execute(removeK3scommand)
+			if err != nil {
+				return err
+			}
+
+			if len(res.StdErr) > 0 {
+				fmt.Printf("stderr: %q", res.StdErr)
+			}
+			if len(res.StdOut) > 0 {
+				fmt.Printf("stdout: %q", res.StdOut)
+			}
+			return nil
+		}
+
+		port, _ := command.Flags().GetInt("ssh-port")
+		fmt.Println("Public IP: " + ip.String())
+
+		user, _ := command.Flags().GetString("user")
+		sshKey, _ := command.Flags().GetString("ssh-key")
+
+		sshKeyPath := expandPath(sshKey)
+		fmt.Printf("ssh -i %s -p %d %s@%s\n", sshKeyPath, port, user, ip.String())
+
+		authMethod, closeSSHAgent, err := loadPublickey(sshKeyPath)
+		if err != nil {
+			return errors.Wrapf(err, "unable to load the ssh key with path %q", sshKeyPath)
+		}
+		defer closeSSHAgent()
+
+		config := &ssh.ClientConfig{
+			User: user,
+			Auth: []ssh.AuthMethod{
+				authMethod,
+			},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		}
+		address := fmt.Sprintf("%s:%d", ip.String(), port)
+		operator, err := operator.NewSSHOperator(address, config)
+		if err != nil {
+			return errors.Wrapf(err, "unable to connect to %s over ssh", address)
+		}
+		defer operator.Close()
+
+		fmt.Printf("ssh: %s\n", removeK3scommand)
+		res, err := operator.Execute(removeK3scommand)
+		if err != nil {
+			return fmt.Errorf("error received processing command: %s", err)
+		}
+
+		fmt.Printf("Result: %s %s\n", string(res.StdOut), string(res.StdErr))
+		return nil
+	}
+
+	command.PreRunE = func(command *cobra.Command, args []string) error {
+		_, ipErr := command.Flags().GetIP("ip")
+		if ipErr != nil {
+			return ipErr
+		}
+
+		_, sshPortErr := command.Flags().GetInt("ssh-port")
+		if sshPortErr != nil {
+			return sshPortErr
+		}
+		return nil
+	}
+	return command
+}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 func main() {
 
 	cmdInstall := cmd.MakeInstall()
+	cmdRemove := cmd.MakeRemove()
 	cmdVersion := cmd.MakeVersion()
 	cmdJoin := cmd.MakeJoin()
 	cmdApps := cmd.MakeApps()
@@ -26,6 +27,7 @@ func main() {
 	}
 
 	rootCmd.AddCommand(cmdInstall)
+	rootCmd.AddCommand(cmdRemove)
 	rootCmd.AddCommand(cmdVersion)
 	rootCmd.AddCommand(cmdJoin)
 	rootCmd.AddCommand(cmdApps)


### PR DESCRIPTION
Signed-off-by: Amal Alkhamees <amalkms5@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This commit will solve issue #106 which will add the remove command to uninstall k3s 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with Centos 8, first installed k3s:
```
$ go run main.go install --ip 165.###### --user centos
Running: k3sup install
Public IP: 165. ######
[INFO]  Using v1.18.6+k3s1 as release
[INFO]  Downloading hash https://github.com/rancher/k3s/releases/download/v1.18.6+k3s1/sha256sum-amd64.txt
[INFO]  Skipping binary downloaded, installed k3s matches hash
[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
[INFO]  Creating /usr/local/bin/crictl symlink to k3s
[INFO]  Creating /usr/local/bin/ctr symlink to k3s
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
[INFO]  systemd: Enabling k3s unit
Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.
[INFO]  systemd: Starting k3s
Result: [INFO]  Using v1.18.6+k3s1 as release
[INFO]  Downloading hash https://github.com/rancher/k3s/releases/download/v1.18.6+k3s1/sha256sum-amd64.txt
[INFO]  Skipping binary downloaded, installed k3s matches hash
[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
[INFO]  Creating /usr/local/bin/crictl symlink to k3s
[INFO]  Creating /usr/local/bin/ctr symlink to k3s
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
[INFO]  systemd: Enabling k3s unit
[INFO]  systemd: Starting k3s
 Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.

apiVersion: v1
clusters:
- cluster:
    certificate-authority-data:  ######
    server: https://127.0.0.1:6443
  name: default
contexts:
- context:
    cluster: default
    user: default
  name: default
current-context: default
kind: Config
preferences: {}
users:
- name: default
  user:
    password: ######
    username: admin
Result: apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: ######
    server: https://127.0.0.1:6443
  name: default
contexts:
- context:
    cluster: default
    user: default
  name: default
current-context: default
kind: Config
preferences: {}
users:
- name: default
  user:
    password: 0c76c10da2a47dbf3fcae12daa8dbe01
    username: admin
 
Saving file to: /Users/###/go/src/github.com/##/k3sup/kubeconfig

# Test your cluster with:
export KUBECONFIG=/Users/###/go/src/github.com/##3/k3sup/kubeconfig
kubectl get node -o wide
``` 
then using the remove command 
```
# go run main.go remove --ip 165.#####--user centos 
Running: k3sup remove
Public IP: 165.#####
ssh -i /Users/######/.ssh/id_rsa -p 22 centos@#####
ssh:  sh /usr/local/bin/k3s-uninstall.sh
++ id -u
+ '[' 1000 -eq 0 ']'
+ exec sudo /usr/local/bin/k3s-uninstall.sh
++ id -u
+ '[' 0 -eq 0 ']'
+ /usr/local/bin/k3s-killall.sh
+ for service in /etc/systemd/system/k3s*.service
+ '[' -s /etc/systemd/system/k3s.service ']'
++ basename /etc/systemd/system/k3s.service
+ systemctl stop k3s.service
+ for service in /etc/init.d/k3s*
+ '[' -x '/etc/init.d/k3s*' ']'
+ killtree
+ kill -9
+ do_unmount /run/k3s
+ do_unmount /var/lib/rancher/k3s
+ do_unmount /var/lib/kubelet/pods
+ do_unmount /run/netns/cni-
+ grep 'master cni0'
+ ip link show
+ read ignore iface ignore
+ ip link delete cni0
Cannot find device "cni0"
+ ip link delete flannel.1
Cannot find device "flannel.1"
+ rm -rf /var/lib/cni/
+ iptables-save
+ grep -v KUBE-
+ iptables-restore
+ grep -v CNI-
+ which systemctl
+ systemctl disable k3s
/bin/systemctl
Removed /etc/systemd/system/multi-user.target.wants/k3s.service.
+ systemctl reset-failed k3s
+ systemctl daemon-reload
+ which rc-update
which: no rc-update in (/sbin:/bin:/usr/sbin:/usr/bin)
+ rm -f /etc/systemd/system/k3s.service
+ rm -f /etc/systemd/system/k3s.service.env
+ trap remove_uninstall EXIT
+ for cmd in kubectl crictl ctr
+ '[' -L /usr/local/bin/kubectl ']'
+ rm -f /usr/local/bin/kubectl
+ for cmd in kubectl crictl ctr
+ '[' -L /usr/local/bin/crictl ']'
+ rm -f /usr/local/bin/crictl
+ for cmd in kubectl crictl ctr
+ '[' -L /usr/local/bin/ctr ']'
+ rm -f /usr/local/bin/ctr
+ rm -rf /etc/rancher/k3s
+ rm -rf /run/k3s
+ rm -rf /run/flannel
+ rm -rf /var/lib/rancher/k3s
+ rm -rf /var/lib/kubelet
+ rm -f /usr/local/bin/k3s
+ rm -f /usr/local/bin/k3s-killall.sh
+ remove_uninstall
+ rm -f /usr/local/bin/k3s-uninstall.sh
Result: /bin/systemctl
 ++ id -u
+ '[' 1000 -eq 0 ']'
+ exec sudo /usr/local/bin/k3s-uninstall.sh
++ id -u
+ '[' 0 -eq 0 ']'
+ /usr/local/bin/k3s-killall.sh
+ for service in /etc/systemd/system/k3s*.service
+ '[' -s /etc/systemd/system/k3s.service ']'
++ basename /etc/systemd/system/k3s.service
+ systemctl stop k3s.service
+ for service in /etc/init.d/k3s*
+ '[' -x '/etc/init.d/k3s*' ']'
+ killtree
+ kill -9
+ do_unmount /run/k3s
+ do_unmount /var/lib/rancher/k3s
+ do_unmount /var/lib/kubelet/pods
+ do_unmount /run/netns/cni-
+ grep 'master cni0'
+ ip link show
+ read ignore iface ignore
+ ip link delete cni0
Cannot find device "cni0"
+ ip link delete flannel.1
Cannot find device "flannel.1"
+ rm -rf /var/lib/cni/
+ iptables-save
+ grep -v KUBE-
+ iptables-restore
+ grep -v CNI-
+ which systemctl
+ systemctl disable k3s
Removed /etc/systemd/system/multi-user.target.wants/k3s.service.
+ systemctl reset-failed k3s
+ systemctl daemon-reload
+ which rc-update
which: no rc-update in (/sbin:/bin:/usr/sbin:/usr/bin)
+ rm -f /etc/systemd/system/k3s.service
+ rm -f /etc/systemd/system/k3s.service.env
+ trap remove_uninstall EXIT
+ for cmd in kubectl crictl ctr
+ '[' -L /usr/local/bin/kubectl ']'
+ rm -f /usr/local/bin/kubectl
+ for cmd in kubectl crictl ctr
+ '[' -L /usr/local/bin/crictl ']'
+ rm -f /usr/local/bin/crictl
+ for cmd in kubectl crictl ctr
+ '[' -L /usr/local/bin/ctr ']'
+ rm -f /usr/local/bin/ctr
+ rm -rf /etc/rancher/k3s
+ rm -rf /run/k3s
+ rm -rf /run/flannel
+ rm -rf /var/lib/rancher/k3s
+ rm -rf /var/lib/kubelet
+ rm -f /usr/local/bin/k3s
+ rm -f /usr/local/bin/k3s-killall.sh
+ remove_uninstall
+ rm -f /usr/local/bin/k3s-uninstall.sh
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
