### PR TITLE
Upgrade to k3s v1.17.7+k3s1

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 // K3sVersion default version
-const K3sVersion = "v1.17.2+k3s1"
+const K3sVersion = "v1.17.7+k3s1"
 
 func InitUserDir() (string, error) {
 	home := os.Getenv("HOME")


### PR DESCRIPTION
Signed-off-by: Hans Rakers <hans@shoq.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgrade k3s to v1.17.7+k3s1

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Update to latest 1.17 patchlevel. There is release for [1.18.4](https://github.com/rancher/k3s/releases/tag/v1.18.4%2Bk3s1) now too but that might introduce breaking changes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
k3sup on  update_k3s via  v1.14.3 ➜ make build
go build
go: downloading github.com/spf13/cobra v0.0.5
go: downloading github.com/morikuni/aec v1.0.0
go: downloading github.com/pkg/errors v0.8.1
go: downloading github.com/mitchellh/go-homedir v1.1.0
go: downloading golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
go: downloading github.com/alexellis/go-execute v0.0.0-20191207085904-961405ea7544
go: downloading golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456
k3sup on  update_k3s via  v1.14.3 ➜ ll
total 15608
-rw-r--r--  1 hans  staff   1.0K Jun 22 08:31 LICENSE
-rw-r--r--  1 hans  staff   1.3K Jun 22 08:31 Makefile
-rw-r--r--  1 hans  staff    19K Jun 22 08:31 README.md
drwxr-xr-x  3 hans  staff    96B Jun 22 08:31 ci/
drwxr-xr-x  8 hans  staff   256B Jun 22 08:31 cmd/
drwxr-xr-x  5 hans  staff   160B Jun 22 08:31 docs/
-rwxr-xr-x  1 hans  staff   4.4K Jun 22 08:31 get.sh*
-rw-r--r--  1 hans  staff   462B Jun 22 08:31 go.mod
-rw-r--r--  1 hans  staff   5.0K Jun 22 08:31 go.sum
drwxr-xr-x  3 hans  staff    96B Jun 22 08:31 hack/
-rwxr-xr-x  1 hans  staff   7.6M Jun 22 08:55 k3sup*
-rw-r--r--  1 hans  staff   665B Jun 22 08:31 main.go
drwxr-xr-x  7 hans  staff   224B Jun 22 08:31 pkg/
drwxr-xr-x  5 hans  staff   160B Jun 22 08:31 vendor/
k3sup on  update_k3s via  v1.14.3 ➜ ./k3sup install --ip 10.135.108.2
Running: k3sup install
Public IP: 10.135.108.2
ssh -i /Users/hans/.ssh/id_rsa -p 22 root@10.135.108.2
ssh: curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server  --tls-san 10.135.108.2 ' INSTALL_K3S_VERSION='v1.17.7+k3s1' sh -

[INFO]  Using v1.17.7+k3s1 as release
[INFO]  Downloading hash https://github.com/rancher/k3s/releases/download/v1.17.7+k3s1/sha256sum-amd64.txt
[INFO]  Downloading binary https://github.com/rancher/k3s/releases/download/v1.17.7+k3s1/k3s
[INFO]  Verifying binary download
[INFO]  Installing k3s to /usr/local/bin/k3s
[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
[INFO]  Creating /usr/local/bin/crictl symlink to k3s
[INFO]  Creating /usr/local/bin/ctr symlink to k3s
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
[INFO]  systemd: Enabling k3s unit
Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.
[INFO]  systemd: Starting k3s
Result: [INFO]  Using v1.17.7+k3s1 as release
[INFO]  Downloading hash https://github.com/rancher/k3s/releases/download/v1.17.7+k3s1/sha256sum-amd64.txt
[INFO]  Downloading binary https://github.com/rancher/k3s/releases/download/v1.17.7+k3s1/k3s
[INFO]  Verifying binary download
[INFO]  Installing k3s to /usr/local/bin/k3s
[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
[INFO]  Creating /usr/local/bin/crictl symlink to k3s
[INFO]  Creating /usr/local/bin/ctr symlink to k3s
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
[INFO]  systemd: Enabling k3s unit
[INFO]  systemd: Starting k3s
 Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.

ssh: sudo cat /etc/rancher/k3s/k3s.yaml

apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJWekNCL3FBREFnRUNBZ0VBTUFvR0NDcUdTTTQ5QkFNQ01DTXhJVEFmQmdOVkJBTU1HR3N6Y3kxelpYSjIKWlhJdFkyRkFNVFU1TWpnd09UZ3dOVEFlRncweU1EQTJNakl3TnpFd01EVmFGdzB6TURBMk1qQXdOekV3TURWYQpNQ014SVRBZkJnTlZCQU1NR0dzemN5MXpaWEoyWlhJdFkyRkFNVFU1TWpnd09UZ3dOVEJaTUJNR0J5cUdTTTQ5CkFnRUdDQ3FHU000OUF3RUhBMElBQk1iSkVaWjREbnlUZDVTWGlOMGVXT0tLN3g2N1psdmlsTVNCclc0QXAyWFMKV3hsYU15OUNBOEFGVU1vYWlSYjVxczFLYzZ0VEhTUGV3Qnd2TjhyVTQvT2pJekFoTUE0R0ExVWREd0VCL3dRRQpBd0lDcERBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUFvR0NDcUdTTTQ5QkFNQ0EwZ0FNRVVDSUZMT2NGSjFmL1IvCjAzSEdkS0J4Rm9CazlsMTBKeWhMbmpsenhMdXZVd2ZmQWlFQWhVeTVXdHhsU2FITWk1MlhzTmxVRTU4SnBvaDIKR1dhU2RScDRJQUQ2U2lzPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
    server: https://127.0.0.1:6443
  name: default
contexts:
- context:
    cluster: default
    user: default
  name: default
current-context: default
kind: Config
preferences: {}
users:
- name: default
  user:
    password: 0802d9b3a57d59b5489a868a0d307c28
    username: admin
Result: apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJWekNCL3FBREFnRUNBZ0VBTUFvR0NDcUdTTTQ5QkFNQ01DTXhJVEFmQmdOVkJBTU1HR3N6Y3kxelpYSjIKWlhJdFkyRkFNVFU1TWpnd09UZ3dOVEFlRncweU1EQTJNakl3TnpFd01EVmFGdzB6TURBMk1qQXdOekV3TURWYQpNQ014SVRBZkJnTlZCQU1NR0dzemN5MXpaWEoyWlhJdFkyRkFNVFU1TWpnd09UZ3dOVEJaTUJNR0J5cUdTTTQ5CkFnRUdDQ3FHU000OUF3RUhBMElBQk1iSkVaWjREbnlUZDVTWGlOMGVXT0tLN3g2N1psdmlsTVNCclc0QXAyWFMKV3hsYU15OUNBOEFGVU1vYWlSYjVxczFLYzZ0VEhTUGV3Qnd2TjhyVTQvT2pJekFoTUE0R0ExVWREd0VCL3dRRQpBd0lDcERBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUFvR0NDcUdTTTQ5QkFNQ0EwZ0FNRVVDSUZMT2NGSjFmL1IvCjAzSEdkS0J4Rm9CazlsMTBKeWhMbmpsenhMdXZVd2ZmQWlFQWhVeTVXdHhsU2FITWk1MlhzTmxVRTU4SnBvaDIKR1dhU2RScDRJQUQ2U2lzPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
    server: https://127.0.0.1:6443
  name: default
contexts:
- context:
    cluster: default
    user: default
  name: default
current-context: default
kind: Config
preferences: {}
users:
- name: default
  user:
    password: 0802d9b3a57d59b5489a868a0d307c28
    username: admin

Saving file to: /Users/hans/dev/k3sup/kubeconfig

# Test your cluster with:
export KUBECONFIG=/Users/hans/dev/k3sup/kubeconfig
kubectl get node -o wide
k3sup on  update_k3s via  v1.14.3 ➜ export KUBECONFIG=/Users/hans/dev/k3sup/kubeconfig
k3sup on  update_k3s via  v1.14.3 ➜ kubectl get node -o wide
NAME       STATUS   ROLES    AGE   VERSION        INTERNAL-IP    EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
k3s-test   Ready    master   30s   v1.17.7+k3s1   10.135.108.2   <none>        Ubuntu 18.04.4 LTS   4.15.0-88-generic   containerd://1.3.3-k3s2
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
