### PR TITLE
Tune verbosity of install/join commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ Other options for `install`:
 * `--k3s-extra-args` - Optional extra arguments to pass to k3s installer, wrapped in quotes, i.e. `--k3s-extra-args '--no-deploy traefik'` or `--k3s-extra-args '--docker'`. For multiple args combine then within single quotes `--k3s-extra-args '--no-deploy traefik --docker'`.
 * `--k3s-version` - set the specific version of k3s, i.e. `v0.9.1`
 - `--ipsec` - Enforces the optional extra argument for k3s: `--flannel-backend` option: `ipsec`
-* See even more install options by running `k3sup install --help`.
+* `--print-command` - Prints out the command, sent over SSH to the remote computer
+
+See even more install options by running `k3sup install --help`.
 
 * Now try the access:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Tune verbosity of install/join commands

## Motivation and Context

In issue #99 and other issues, users have become confused by seeing a helper string being printed out such as:

```
ssh -I pub-key-path -p PORT user@IP
```

Going forward this string will be removed completely

Any commands ran by k3sup are also being removed from the output, unless users specifically want to see them, in which case, they are available via adding `--print-command`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested against three DigitalOcean droplets, the SSH info was not printed, as expected, for the final agent, the command was added and the output was printed again.
