### PR TITLE
Remove extra quotes that was causing k3sup install to fail when passed the --ipsec flag

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -103,7 +103,7 @@ Provide the --local-path flag with --merge if a kubeconfig already exists in som
 			k3sExtraArgs += `--flannel-backend ipsec`
 		}
 		if k3sNoExtras {
-			k3sExtraArgs += `--no-deploy servicelb --no-deploy traefik`
+			k3sExtraArgs += ` --no-deploy servicelb --no-deploy traefik`
 		}
 
 		installk3sExec := fmt.Sprintf("INSTALL_K3S_EXEC='server %s --tls-san %s %s'", clusterStr, ip, strings.TrimSpace(k3sExtraArgs))

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -100,7 +100,7 @@ Provide the --local-path flag with --merge if a kubeconfig already exists in som
 		}
 
 		if flannelIPSec {
-			k3sExtraArgs += ` '--flannel-backend ipsec'`
+			k3sExtraArgs += `--flannel-backend ipsec`
 		}
 		if k3sNoExtras {
 			k3sExtraArgs += `--no-deploy servicelb --no-deploy traefik`

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -99,11 +99,11 @@ Provide the --local-path flag with --merge if a kubeconfig already exists in som
 				return fmt.Errorf("you must specify the mysql host as tcp(host:port) or tcp(ip:port), see the k3s docs for more: https://rancher.com/docs/k3s/latest/en/installation/ha")
 			}
 
-			k3sExtraArgsSlice = append(k3sExtraArgsSlice, "--datastore-endpoint" + datastore)
+			k3sExtraArgsSlice = append(k3sExtraArgsSlice, "--datastore-endpoint"+datastore)
 		}
 
 		if flannelIPSec {
-			k3sExtraArgsSlice = append(k3sExtraArgsSlice,`--flannel-backend ipsec`)
+			k3sExtraArgsSlice = append(k3sExtraArgsSlice, `--flannel-backend ipsec`)
 		}
 		if k3sNoExtras {
 			k3sExtraArgsSlice = append(k3sExtraArgsSlice, `--no-deploy servicelb --no-deploy traefik`)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes the single quotes around --flanel-backend ipsec that was causing the command to fail.
## Motivation and Context
Fix issues -> https://github.com/alexellis/k3sup/issues/183 and https://github.com/alexellis/k3sup/issues/245
- [x] I have raised an issue to propose this change ([required] Was raised by someone else.(https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
I ran before and after runs of  binary on MacOS and observed it to work and verified with the --print-command that the extra quotes were removed.

The commands I used to test was this
```
./k3sup install \
  --print-command \
   --ip $SERVER_IP \
    --user $USER \
    --cluster \
   --ssh-key ~/.ssh/bob.key
```
I built the new binary on MacOS only and validated the above on MacOS only.

Have also ran the following manual tests
```
 ./k3sup install --print-command --ssh-key ~/.ssh/bob.key --ip=192.168.1.34 --user=root --cluster --no-extras
Running: k3sup install
Public IP: 192.168.1.34
Enter passphrase for ‘~/.ssh/bob.key': 
ssh: curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --cluster-init --tls-san 192.168.1.34 --no-deploy servicelb --no-deploy traefik' INSTALL_K3S_VERSION='v1.18.6+k3s1' sh -

./k3sup install --print-command --ssh-key ~/.ssh/bob.key --ip=192.168.1.34 --user=root --cluster --no-extras --k3s-extra-args='--flannel-backend=host-gw'
Running: k3sup install
Public IP: 192.168.1.34
Enter passphrase for '~/.ssh/bob.key': 
ssh: curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --cluster-init --tls-san 1192.168.1.34  --flannel-backend=host-gw --no-deploy servicelb --no-deploy traefik' INSTALL_K3S_VERSION='v1.18.6+k3s1' sh -

./k3sup install --print-command --ssh-key ~/.ssh/bob.key --ip=192.168.1.34  --user=root --cluster --ipsec
Running: k3sup install
Public IP: 192.168.1.34 
Enter passphrase for '~/.ssh/bob.key': 
ssh: curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --cluster-init --tls-san 192.168.1.34  --flannel-backend ipsec' INSTALL_K3S_VERSION='v1.18.6+k3s1' sh -

./k3sup install --print-command ~/.ssh/bob.key --ip=192.168.1.34  --user=root --cluster --ipsec --no-extras
Running: k3sup install
Public IP: 192.168.1.34
Enter passphrase for '~/.ssh/bob.key’ : 
ssh: curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --cluster-init --tls-san 192.168.1.34 --flannel-backend ipsec --no-deploy servicelb --no-deploy traefik' INSTALL_K3S_VERSION='v1.18.6+k3s1' sh -

./k3sup install --print-command ~/.ssh/bob.key --ip=192.168.1.34 --user=root --cluster --no-extras --k3s-extra-args='--flannel-backend=host-gw --datastore-endpoint=bobtest'
Running: k3sup install
Public IP: 192.168.1.34 
Enter passphrase for '~/.ssh/bob.key': 
ssh: curl -sLS https://get.k3s.io | INSTALL_K3S_EXEC='server --cluster-init --tls-san 192.168.1.34  --flannel-backend=host-gw --datastore-endpoint=bobtest --no-deploy servicelb --no-deploy traefik' INSTALL_K3S_VERSION='v1.18.6+k3s1' sh -
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
