### PR TITLE
Replace deprecated --no-deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Other options for `install`:
 * `--merge` - Merge config into existing file instead of overwriting (e.g. to add config to the default kubectl config, use `--local-path ~/.kube/config --merge`).
 * `--context` - default is `default` - set the name of the kubeconfig context.
 * `--ssh-port` - default is `22`, but you can specify an alternative port i.e. `2222`
-* `--k3s-extra-args` - Optional extra arguments to pass to k3s installer, wrapped in quotes, i.e. `--k3s-extra-args '--no-deploy traefik'` or `--k3s-extra-args '--docker'`. For multiple args combine then within single quotes `--k3s-extra-args '--no-deploy traefik --docker'`.
+* `--k3s-extra-args` - Optional extra arguments to pass to k3s installer, wrapped in quotes, i.e. `--k3s-extra-args '--disable traefik'` or `--k3s-extra-args '--docker'`. For multiple args combine then within single quotes `--k3s-extra-args '--disable traefik --docker'`.
 * `--k3s-version` - set the specific version of k3s, i.e. `v0.9.1`
 - `--ipsec` - Enforces the optional extra argument for k3s: `--flannel-backend` option: `ipsec`
 * `--print-command` - Prints out the command, sent over SSH to the remote computer

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -41,7 +41,7 @@ func MakeInstall() *cobra.Command {
 	command.Flags().Bool("skip-install", false, "Skip the k3s installer")
 	command.Flags().String("local-path", "kubeconfig", "Local path to save the kubeconfig file")
 	command.Flags().String("context", "default", "Set the name of the kubeconfig context.")
-	command.Flags().String("k3s-extra-args", "", "Optional extra arguments to pass to k3s installer, wrapped in quotes (e.g. --k3s-extra-args '--no-deploy servicelb')")
+	command.Flags().String("k3s-extra-args", "", "Optional extra arguments to pass to k3s installer, wrapped in quotes (e.g. --k3s-extra-args '--disable servicelb')")
 	command.Flags().Bool("no-extras", false, `Disable "servicelb" and "traefik"`)
 
 	command.Flags().Bool("ipsec", false, "Enforces and/or activates optional extra argument for k3s: flannel-backend option: ipsec")
@@ -103,7 +103,7 @@ Provide the --local-path flag with --merge if a kubeconfig already exists in som
 			k3sExtraArgs += ` '--flannel-backend ipsec'`
 		}
 		if k3sNoExtras {
-			k3sExtraArgs += `--no-deploy servicelb --no-deploy traefik`
+			k3sExtraArgs += `--disable servicelb --disable traefik`
 		}
 
 		installk3sExec := fmt.Sprintf("INSTALL_K3S_EXEC='server %s --tls-san %s %s'", clusterStr, ip, strings.TrimSpace(k3sExtraArgs))


### PR DESCRIPTION
## Description
The `--no-deploy` option is deprecated and was replaced with `--disable` option in k3s

## Motivation and Context
A deprecated option will be removed in future, so change it before it happens

## How Has This Been Tested?
--disable is a drop-in replacement, but i've tested it by using  `--k3s-extra-args "--disable traefik,servicelb"`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) **<= for recent versions of k3s** 
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change) **<= for older versions of k3s**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
