### PR TITLE
Add release channel support and fix string concatenation during install

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -426,7 +426,7 @@ func makeInstallExec(cluster bool, ip net.IP, tlsSAN string, options k3sExecOpti
 		extraArgs = append(extraArgs, fmt.Sprintf("--datastore-endpoint %s", options.Datastore))
 	}
 	if options.FlannelIPSec {
-		extraArgs = append(extraArgs, fmt.Sprintf("'--flannel-backend %s'", "ipsec"))
+		extraArgs = append(extraArgs, "--flannel-backend ipsec")
 	}
 
 	if options.NoExtras {

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -205,6 +205,27 @@ func Test_makeInstallExec_SAN(t *testing.T) {
 	}
 }
 
+func Test_makeInstallExec_IPSec(t *testing.T) {
+	cluster := false
+	datastore := ""
+	flannelIPSec := true
+	k3sNoExtras := false
+	k3sExtraArgs := ""
+	ip := net.ParseIP("127.0.0.1")
+	tlsSAN := ""
+	got := makeInstallExec(cluster, ip, tlsSAN,
+		k3sExecOptions{
+			Datastore:    datastore,
+			FlannelIPSec: flannelIPSec,
+			NoExtras:     k3sNoExtras,
+			ExtraArgs:    k3sExtraArgs,
+		})
+	want := "INSTALL_K3S_EXEC='server --tls-san 127.0.0.1 --flannel-backend ipsec'"
+	if got != want {
+		t.Errorf("want: %q, got: %q", want, got)
+	}
+}
+
 func Test_makeInstallExec_Datastore(t *testing.T) {
 	cluster := false
 	datastore := "mysql://doadmin:show-password@tcp(db-mysql-lon1-40939-do-user-2197152-0.b.db.ondigitalocean.com:25060)/defaultdb"

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -84,9 +84,15 @@ func MakeJoin() *cobra.Command {
 			return fmt.Errorf("give a value for --k3s-version or --k3s-channel")
 		}
 
-		printCommand, _ := command.Flags().GetBool("print-command")
+		printCommand, err := command.Flags().GetBool("print-command")
+		if err != nil {
+			return err
+		}
 
-		useSudo, _ := command.Flags().GetBool("sudo")
+		useSudo, err := command.Flags().GetBool("sudo")
+		if err != nil {
+			return err
+		}
 		sudoPrefix := ""
 		if useSudo {
 			sudoPrefix = "sudo "

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,9 +6,6 @@ import (
 	"path"
 )
 
-// K3sVersion default version
-const K3sVersion = "v1.18.6+k3s1"
-
 func InitUserDir() (string, error) {
 	home := os.Getenv("HOME")
 	root := fmt.Sprintf("%s/.k3sup/", home)


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add release channel support and fix string concatenation during install

## Motivation and Context

Moves from using a pinned version, to a pinned channel -
in this instance from a specific 1.18 version to a 1.18
channel, so that patch releases are installed as available.

Fixes: #237
Closes: #266
Fixes: #268

## How Has This Been Tested?

This changes the install and join commands, so community testing is welcomed.

Tested with unit tests and with DigitalOcean as a backend with MySQL:

```
go build && ./k3sup install --ip 192.168.0.101 --datastore "$DATASTORE" --print-command --user pi --k3s-extra-args '--no-deploy servicelb' --k3s-channel latest
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
