### PR TITLE
 Add makeJoinExec function to scaffold SSH commands

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const getScript = "curl -sfL https://get.k3s.io"
+
 func MakeApps() *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "app",

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -148,7 +148,7 @@ Provide the --local-path flag with --merge if a kubeconfig already exists in som
 
 		installStr := createVersionStr(k3sVersion, k3sChannel)
 
-		installK3scommand := fmt.Sprintf("curl -sLS https://get.k3s.io | %s %s sh -\n", installk3sExec, installStr)
+		installK3scommand := fmt.Sprintf("%s | %s %s sh -\n", getScript, installk3sExec, installStr)
 
 		getConfigcommand := fmt.Sprintf(sudoPrefix + "cat /etc/rancher/k3s/k3s.yaml\n")
 

--- a/cmd/join_test.go
+++ b/cmd/join_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"testing"
+)
+
+type test struct {
+	serverIP       string
+	joinToken      string
+	installStr     string
+	installk3sExec string
+	k3sExtraArgs   string
+}
+
+func Test_makeJoinExec(t *testing.T) {
+	tests := []test{
+		{
+			serverIP:       "172.27.251.164",
+			joinToken:      "K10c8bc21f68fef3f56d431a08df2e894481ab0a61a3c84cbd639b56449ad15523c::server:9d30861e1ba54177b8e4dd1426076e5d",
+			installStr:     "INSTALL_K3S_VERSION=1.18",
+			installk3sExec: "K3S_URL='https://172.27.251.164:6443' INSTALL_K3S_EXEC='server --server https://172.27.251.164:6443' K3S_TOKEN='K10c8bc21f68fef3f56d431a08df2e894481ab0a61a3c84cbd639b56449ad15523c::server:9d30861e1ba54177b8e4dd1426076e5d' INSTALL_K3S_VERSION=1.18 sh -s -",
+			k3sExtraArgs:   "",
+		},
+
+		{
+			serverIP:       "172.27.251.164",
+			joinToken:      "K10c8bc21f68fef3f56d431a08df2e894481ab0a61a3c84cbd639b56449ad15523c::server:9d30861e1ba54177b8e4dd1426076e5d",
+			installStr:     "INSTALL_K3S_VERSION=1.18",
+			installk3sExec: "K3S_URL='https://172.27.251.164:6443' INSTALL_K3S_EXEC='server --server https://172.27.251.164:6443' K3S_TOKEN='K10c8bc21f68fef3f56d431a08df2e894481ab0a61a3c84cbd639b56449ad15523c::server:9d30861e1ba54177b8e4dd1426076e5d' INSTALL_K3S_VERSION=1.18 sh -s - --node-taint key=value:NoExecute",
+			k3sExtraArgs:   "--node-taint key=value:NoExecute",
+		},
+	}
+
+	for _, tc := range tests {
+		got := makeJoinServerExec(tc.serverIP, tc.joinToken, tc.installStr, tc.k3sExtraArgs)
+
+		if got != tc.installk3sExec {
+			t.Errorf("want: %s, got: %s", tc.installk3sExec, got)
+		}
+	}
+
+}

--- a/cmd/join_test.go
+++ b/cmd/join_test.go
@@ -5,38 +5,78 @@ import (
 )
 
 type test struct {
+	title          string
 	serverIP       string
 	joinToken      string
 	installStr     string
-	installk3sExec string
 	k3sExtraArgs   string
+	serverAgent    bool
+	installk3sExec string
 }
 
-func Test_makeJoinExec(t *testing.T) {
+func Test_makeJoinServerExec(t *testing.T) {
 	tests := []test{
 		{
+			title:          "Join Server without k3sExtraArgs",
 			serverIP:       "172.27.251.164",
 			joinToken:      "K10c8bc21f68fef3f56d431a08df2e894481ab0a61a3c84cbd639b56449ad15523c::server:9d30861e1ba54177b8e4dd1426076e5d",
 			installStr:     "INSTALL_K3S_VERSION=1.18",
-			installk3sExec: "K3S_URL='https://172.27.251.164:6443' INSTALL_K3S_EXEC='server --server https://172.27.251.164:6443' K3S_TOKEN='K10c8bc21f68fef3f56d431a08df2e894481ab0a61a3c84cbd639b56449ad15523c::server:9d30861e1ba54177b8e4dd1426076e5d' INSTALL_K3S_VERSION=1.18 sh -s -",
+			installk3sExec: "K3S_URL='https://172.27.251.164:6443' K3S_TOKEN='K10c8bc21f68fef3f56d431a08df2e894481ab0a61a3c84cbd639b56449ad15523c::server:9d30861e1ba54177b8e4dd1426076e5d' INSTALL_K3S_VERSION=1.18 INSTALL_K3S_EXEC='server --server https://172.27.251.164:6443' sh -s -",
 			k3sExtraArgs:   "",
+			serverAgent:    true,
 		},
 
 		{
+			title:          "Join Server with K3sExtraArgs",
 			serverIP:       "172.27.251.164",
 			joinToken:      "K10c8bc21f68fef3f56d431a08df2e894481ab0a61a3c84cbd639b56449ad15523c::server:9d30861e1ba54177b8e4dd1426076e5d",
 			installStr:     "INSTALL_K3S_VERSION=1.18",
-			installk3sExec: "K3S_URL='https://172.27.251.164:6443' INSTALL_K3S_EXEC='server --server https://172.27.251.164:6443' K3S_TOKEN='K10c8bc21f68fef3f56d431a08df2e894481ab0a61a3c84cbd639b56449ad15523c::server:9d30861e1ba54177b8e4dd1426076e5d' INSTALL_K3S_VERSION=1.18 sh -s - --node-taint key=value:NoExecute",
+			installk3sExec: "K3S_URL='https://172.27.251.164:6443' K3S_TOKEN='K10c8bc21f68fef3f56d431a08df2e894481ab0a61a3c84cbd639b56449ad15523c::server:9d30861e1ba54177b8e4dd1426076e5d' INSTALL_K3S_VERSION=1.18 INSTALL_K3S_EXEC='server --server https://172.27.251.164:6443' sh -s - --node-taint key=value:NoExecute",
 			k3sExtraArgs:   "--node-taint key=value:NoExecute",
+			serverAgent:    true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.title, func(t *testing.T) {
+			got := makeJoinExec(tc.serverIP, tc.joinToken, tc.installStr, tc.k3sExtraArgs, tc.serverAgent)
+
+			if got != tc.installk3sExec {
+				t.Errorf("want: %s, got: %s", tc.installk3sExec, got)
+			}
+		})
+	}
+
+}
+
+func Test_makeJoinAgentExec(t *testing.T) {
+	tests := []test{
+		{
+			title:          "Join Agent without K3sExtraArgs",
+			serverIP:       "172.27.251.164",
+			joinToken:      "K10c8bc21f68fef3f56d431a08df2e894481ab0a61a3c84cbd639b56449ad15523c::server:9d30861e1ba54177b8e4dd1426076e5d",
+			installStr:     "INSTALL_K3S_VERSION=1.18",
+			k3sExtraArgs:   "",
+			serverAgent:    false,
+			installk3sExec: "K3S_URL='https://172.27.251.164:6443' K3S_TOKEN='K10c8bc21f68fef3f56d431a08df2e894481ab0a61a3c84cbd639b56449ad15523c::server:9d30861e1ba54177b8e4dd1426076e5d' INSTALL_K3S_VERSION=1.18 sh -s -",
+		},
+		{
+			title:          "Join Agent with K3sExtraArgs",
+			serverIP:       "172.27.251.164",
+			joinToken:      "K10c8bc21f68fef3f56d431a08df2e894481ab0a61a3c84cbd639b56449ad15523c::server:9d30861e1ba54177b8e4dd1426076e5d",
+			installStr:     "INSTALL_K3S_VERSION=1.18",
+			installk3sExec: "K3S_URL='https://172.27.251.164:6443' K3S_TOKEN='K10c8bc21f68fef3f56d431a08df2e894481ab0a61a3c84cbd639b56449ad15523c::server:9d30861e1ba54177b8e4dd1426076e5d' INSTALL_K3S_VERSION=1.18 sh -s - --node-taint key=value:NoExecute",
+			k3sExtraArgs:   "--node-taint key=value:NoExecute",
+			serverAgent:    false,
 		},
 	}
 
 	for _, tc := range tests {
-		got := makeJoinServerExec(tc.serverIP, tc.joinToken, tc.installStr, tc.k3sExtraArgs)
+		t.Run(tc.title, func(t *testing.T) {
+			got := makeJoinExec(tc.serverIP, tc.joinToken, tc.installStr, tc.k3sExtraArgs, tc.serverAgent)
 
-		if got != tc.installk3sExec {
-			t.Errorf("want: %s, got: %s", tc.installk3sExec, got)
-		}
+			if got != tc.installk3sExec {
+				t.Errorf("want: %s, got: %s", tc.installk3sExec, got)
+			}
+		})
 	}
-
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added `makeJoinExec` function to scaffold SSH commands replacing string interpolated command generation.
Added tests for both `setupAdditionalServer`  and `setupAgent`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
**Steps:** 

1. Created two 3VMs using Multipass.
2. Installed k3s on master node using `k3sup install` 
3. Added Agent as a master server with the existing server. using `k3sup join --server` 
4. Added agent as a worker node using `k3sup join`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

![image](https://user-images.githubusercontent.com/13623913/97078175-e48e9b80-1609-11eb-8685-c2245fd8e827.png)