### PR TITLE
Add uninstall sub-command.

### DIFF
--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"fmt"
+	"net"
+
+	operator "github.com/alexellis/k3sup/pkg/operator"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh"
+)
+
+func MakeUninstall() *cobra.Command {
+	var command = &cobra.Command{
+		Use:          "uninstall",
+		Short:        "Uninstall k3s from a node",
+		Long:         "Uninstall k3s from a node",
+		Example:      `k3sup uninstall --ip 192.168.0.100 --user root`,
+		SilenceUsage: true,
+	}
+	command.Flags().IP("ip", net.ParseIP("127.0.0.1"), "Public IP of node")
+	command.Flags().String("user", "root", "Username for SSH login")
+	command.Flags().String("ssh-key", "~/.ssh/id_rsa", "The ssh key to use for remote login")
+	command.Flags().Int("ssh-port", 22, "The port on which to connect for ssh")
+	command.Flags().Bool("server", false, "Remove a server node")
+
+	command.RunE = func(command *cobra.Command, args []string) error {
+		fmt.Printf("Running: k3sup uninstall\n")
+
+		ip, _ := command.Flags().GetIP("ip")
+		fmt.Println("IP: " + ip.String())
+
+		user, _ := command.Flags().GetString("user")
+
+		port, _ := command.Flags().GetInt("ssh-port")
+		serverPort := port
+
+		sshKey, _ := command.Flags().GetString("ssh-key")
+
+		server, getServerErr := command.Flags().GetBool("server")
+		if getServerErr != nil {
+			return getServerErr
+		}
+
+		sshKeyPath := expandPath(sshKey)
+		fmt.Println(sshKeyPath)
+		authMethod, closeSSHAgent, err := loadPublickey(sshKeyPath)
+		if err != nil {
+			return errors.Wrapf(err, "unable to load the ssh key with path %q", sshKeyPath)
+		}
+
+		defer closeSSHAgent()
+
+		config := &ssh.ClientConfig{
+			User: user,
+			Auth: []ssh.AuthMethod{
+				authMethod,
+			},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		}
+
+		address := fmt.Sprintf("%s:%d", ip.String(), serverPort)
+		operator, err := operator.NewSSHOperator(address, config)
+
+		if err != nil {
+			return errors.Wrapf(err, "unable to connect to (server) %s over ssh", address)
+		}
+
+		defer operator.Close()
+
+		var uninstallCommand string
+		if server {
+			uninstallCommand = fmt.Sprintf("sh /usr/local/bin/k3s-uninstall.sh\n")
+		} else {
+			uninstallCommand = fmt.Sprintf("sh /usr/local/bin/k3s-agent-uninstall.sh\n")
+		}
+
+		res, err := operator.Execute(uninstallCommand)
+		if err != nil {
+			return errors.Wrap(err, "unable to uninstall k3s from the node")
+		}
+
+		if len(res.StdErr) > 0 {
+			fmt.Printf("Logs: %s", res.StdErr)
+		}
+
+		closeSSHAgent()
+		operator.Close()
+
+		fmt.Println(UninstallInfoMsg)
+
+		return nil
+	}
+
+	command.PreRunE = func(command *cobra.Command, args []string) error {
+		_, ipErr := command.Flags().GetIP("ip")
+		if ipErr != nil {
+			return ipErr
+		}
+
+		_, sshPortErr := command.Flags().GetInt("ssh-port")
+		if sshPortErr != nil {
+			return sshPortErr
+		}
+		return nil
+	}
+	return command
+}
+
+const UninstallInfoMsg = `
+# k3s has been uninstalled from the node
+
+## To delete the node from your cluster, run:
+
+kubectl delete node <node-name>
+`

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ func main() {
 	cmdJoin := cmd.MakeJoin()
 	cmdApps := cmd.MakeApps()
 	cmdUpdate := cmd.MakeUpdate()
+	cmdUninstall := cmd.MakeUninstall()
 
 	printk3supASCIIArt := cmd.PrintK3supASCIIArt
 
@@ -30,6 +31,7 @@ func main() {
 	rootCmd.AddCommand(cmdJoin)
 	rootCmd.AddCommand(cmdApps)
 	rootCmd.AddCommand(cmdUpdate)
+	rootCmd.AddCommand(cmdUninstall)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
Uninstall sub-command for  server and agent.

Signed-off-by: yankeexe <yankee.exe@gmail.com>

## Todo 
 - [ ] Add `--host` flag support.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added Uninstall sub-command to run the uninstallation script for both server and agent. 
For server: has additional `--server` flag.

```bash 
$ k3sup uninstall --ip <ip> --user <user> --server
```


For agent: 

```bash 
$ k3sup uninstall --ip <ip> --user <user> 
```

**Need to discuss:** 
1. how to go forward uninstalling k3s and deleting agent nodes when master k3s is uninstalled from the master node.
2. Deleting node once k3s has been uninstalled from the agent node. (show uninstall instruction or k3sup does it for you?)


## **Update** 
Based on the questions I have asked [here](https://www.youtube.com/watch?v=k58WnbKmjdA), yanking k3s from the node is a manual process and the user has to go through each node to delete k3s from it.

Apart from the uninstall script, it is recommended to delete, `/var/lib/rancher/k3s` to start from a clean slate.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Easy uninstall k3s from command line without having to ssh into server and do it manually.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. create 2 multipass instances. 
2. install master in one, and agent on the next. 
3. run `uninstall` sub command against both the nodes. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
