### PR TITLE
Add hostname support for install/join

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ Imagine the IP was `192.168.0.1` and the username was `ubuntu`, then you would r
 ```sh
 export IP=192.168.0.1
 k3sup install --ip $IP --user ubuntu
+
+# Or use a hostname and SSH key for EC2
+export HOST="ec2-3-250-131-77.eu-west-1.compute.amazonaws.com"
+k3sup install --host $HOST --user ubuntu \
+  --ssh-key $HOME/ec2-key.pem
 ```
 
 Other options for `install`:

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -37,10 +37,13 @@ const PinnedK3sChannel = "v1.19"
 
 func MakeInstall() *cobra.Command {
 	var command = &cobra.Command{
-		Use:          "install",
-		Short:        "Install k3s on a server via SSH",
-		Long:         `Install k3s on a server via SSH.`,
-		Example:      `  k3sup install --ip 192.168.0.100 --user root`,
+		Use:   "install",
+		Short: "Install k3s on a server via SSH",
+		Long:  `Install k3s on a server via SSH.`,
+		Example: `  k3sup install --ip 192.168.0.100 --user root
+  k3sup install --ip 192.168.0.100 --k3s-channel latest
+  k3sup install --host ec2-3-250-131-77.eu-west-1.compute.amazonaws.com \
+    --ssh-key ~/ec2-key.pem --user ubuntu`,
 		SilenceUsage: true,
 	}
 

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"io/ioutil"
-	"net"
 	"os"
 	"regexp"
 	"strings"
@@ -148,7 +147,7 @@ func Test_makeInstallExec(t *testing.T) {
 	flannelIPSec := false
 	k3sNoExtras := false
 	k3sExtraArgs := ""
-	ip := net.ParseIP("127.0.0.1")
+	ip := "raspberrypi.local"
 	tlsSAN := ""
 	got := makeInstallExec(cluster, ip, tlsSAN,
 		k3sExecOptions{
@@ -157,7 +156,7 @@ func Test_makeInstallExec(t *testing.T) {
 			NoExtras:     k3sNoExtras,
 			ExtraArgs:    k3sExtraArgs,
 		})
-	want := "INSTALL_K3S_EXEC='server --tls-san 127.0.0.1'"
+	want := "INSTALL_K3S_EXEC='server --tls-san raspberrypi.local'"
 	if got != want {
 		t.Errorf("want: %q, got: %q", want, got)
 	}
@@ -169,7 +168,7 @@ func Test_makeInstallExec_Cluster(t *testing.T) {
 	flannelIPSec := false
 	k3sNoExtras := false
 	k3sExtraArgs := ""
-	ip := net.ParseIP("127.0.0.1")
+	ip := "127.0.0.1"
 	tlsSAN := ""
 	got := makeInstallExec(cluster, ip, tlsSAN,
 		k3sExecOptions{
@@ -190,7 +189,7 @@ func Test_makeInstallExec_SAN(t *testing.T) {
 	flannelIPSec := false
 	k3sNoExtras := false
 	k3sExtraArgs := ""
-	ip := net.ParseIP("127.0.0.1")
+	ip := "127.0.0.1"
 	tlsSAN := "192.168.0.1"
 	got := makeInstallExec(cluster, ip, tlsSAN,
 		k3sExecOptions{
@@ -211,7 +210,7 @@ func Test_makeInstallExec_IPSec(t *testing.T) {
 	flannelIPSec := true
 	k3sNoExtras := false
 	k3sExtraArgs := ""
-	ip := net.ParseIP("127.0.0.1")
+	ip := "127.0.0.1"
 	tlsSAN := ""
 	got := makeInstallExec(cluster, ip, tlsSAN,
 		k3sExecOptions{
@@ -232,7 +231,7 @@ func Test_makeInstallExec_Datastore(t *testing.T) {
 	flannelIPSec := false
 	k3sNoExtras := false
 	k3sExtraArgs := ""
-	ip := net.ParseIP("127.0.0.1")
+	ip := "127.0.0.1"
 	tlsSAN := "192.168.0.1"
 	got := makeInstallExec(cluster, ip, tlsSAN,
 		k3sExecOptions{
@@ -253,7 +252,7 @@ func Test_makeInstallExec_Datastore_NoExtras(t *testing.T) {
 	flannelIPSec := false
 	k3sNoExtras := true
 	k3sExtraArgs := ""
-	ip := net.ParseIP("127.0.0.1")
+	ip := "raspberrypi.local"
 	tlsSAN := "192.168.0.1"
 	got := makeInstallExec(cluster, ip, tlsSAN,
 		k3sExecOptions{

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -13,10 +13,13 @@ import (
 
 func MakeJoin() *cobra.Command {
 	var command = &cobra.Command{
-		Use:          "join",
-		Short:        "Install the k3s agent on a remote host and join it to an existing server",
-		Long:         `Install the k3s agent on a remote host and join it to an existing server`,
-		Example:      `  k3sup join --user root --server-ip 192.168.0.100 --ip 192.168.0.101`,
+		Use:   "join",
+		Short: "Install the k3s agent on a remote host and join it to an existing server",
+		Long:  `Install the k3s agent on a remote host and join it to an existing server`,
+		Example: `  k3sup join --user root --server-ip 192.168.0.100 --ip 192.168.0.101
+  k3sup join --user pi --server-host server-pi1.local \
+	--host agent-pi1.local \
+	--k3s-channel latest`,
 		SilenceUsage: true,
 	}
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add hostname support for install/join

## Motivation and Context

Adds --host / --server-host to the install and join commands
so that a DNS entry can be used. The DNS entry is not resolved
or validated to avoid a depency on a DNS package and CGO.

Fixes: #131
Closes: #271
Closes: #227

## How Has This Been Tested?

Tested on two AWS instances with their DNS entry instead of
their IP addresses.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
