### PR TITLE
Update CLI wordings per k3s versions 1.19.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ k3sup install --host $HOST --user ubuntu \
 
 Other options for `install`:
 
-* `--cluster` - start this server in clustering mode, for use with dqlite (embedded HA)
+* `--cluster` - start this server in clustering mode using embdeed etcd (embedded HA)
 * `--skip-install` - if you already have k3s installed, you can just run this command to get the `kubeconfig`
 * `--ssh-key` - specify a specific path for the SSH key for remote login
 * `--local-path` - default is `./kubeconfig` - set the file where you want to save your cluster's `kubeconfig`.  By default this file will be overwritten.

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -65,7 +65,7 @@ func MakeInstall() *cobra.Command {
 	command.Flags().Bool("merge", false, `Merge the config with existing kubeconfig if it already exists.
 Provide the --local-path flag with --merge if a kubeconfig already exists in some other directory`)
 	command.Flags().Bool("local", false, "Perform a local install without using ssh")
-	command.Flags().Bool("cluster", false, "Form a dqlite cluster")
+	command.Flags().Bool("cluster", false, "HA cluster using embedded etcd")
 
 	command.Flags().Bool("print-command", false, "Print a command that you can use with SSH to manually recover from an error")
 	command.Flags().String("datastore", "", "Optional: connection-string for the k3s datastore to enable HA, i.e. \"mysql://username:password@tcp(hostname:3306)/database-name\"")


### PR DESCRIPTION
Signed-off-by: Noel Georgi <git@frezbo.com>

K3S v1.19.1+ has replaced dqlite with etcd.

## Description
Update CLI wordings to reflect usage of embedded etcd

## Motivation and Context
Ref: https://rancher.com/docs/k3s/latest/en/installation/ha-embedded/

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ x ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ x ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
