### PR TITLE
Don't print the kubeconfig by default

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -278,15 +278,14 @@ Provide the --local-path flag with --merge if a kubeconfig already exists in som
 	}
 
 	command.PreRunE = func(command *cobra.Command, args []string) error {
-		_, ipErr := command.Flags().GetIP("ip")
-		if ipErr != nil {
-			return ipErr
+		if _, err := command.Flags().GetIP("ip"); err != nil {
+			return err
 		}
 
-		_, sshPortErr := command.Flags().GetInt("ssh-port")
-		if sshPortErr != nil {
-			return sshPortErr
+		if _, err := command.Flags().GetInt("ssh-port"); err != nil {
+			return err
 		}
+
 		return nil
 	}
 	return command
@@ -315,8 +314,8 @@ func obtainKubeconfig(operator operator.CommandOperator, getConfigcommand, host,
 	}
 
 	// Create a new kubeconfig
-	if writeErr := writeConfig(absPath, []byte(kubeconfig), context, false); writeErr != nil {
-		return writeErr
+	if err := writeConfig(absPath, []byte(kubeconfig), context, false); err != nil {
+		return err
 	}
 
 	return nil
@@ -353,8 +352,8 @@ func mergeConfigs(localKubeconfigPath, context string, k3sconfig []byte) ([]byte
 	}
 	defer file.Close()
 
-	if writeErr := writeConfig(file.Name(), []byte(k3sconfig), context, true); writeErr != nil {
-		return nil, writeErr
+	if err := writeConfig(file.Name(), []byte(k3sconfig), context, true); err != nil {
+		return nil, err
 	}
 
 	fmt.Printf("Merging with existing kubeconfig at %s\n", localKubeconfigPath)

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -84,9 +84,9 @@ func MakeJoin() *cobra.Command {
 		}
 
 		sshKey, _ := command.Flags().GetString("ssh-key")
-		server, getServerErr := command.Flags().GetBool("server")
-		if getServerErr != nil {
-			return getServerErr
+		server, err := command.Flags().GetBool("server")
+		if err != nil {
+			return err
 		}
 
 		port, _ := command.Flags().GetInt("ssh-port")

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -38,12 +38,12 @@ func MakeJoin() *cobra.Command {
 	command.Flags().Bool("skip-install", false, "Skip the k3s installer")
 	command.Flags().Bool("sudo", true, "Use sudo for installation. e.g. set to false when using the root user and no sudo is available.")
 
-	command.Flags().Bool("server", false, "Join the cluster as a server rather than as an agent")
+	command.Flags().Bool("server", false, "Join the cluster as a server rather than as an agent for the embedded etcd mode")
 	command.Flags().Bool("print-command", false, "Print a command that you can use with SSH to manually recover from an error")
 
-	command.Flags().String("k3s-extra-args", "", "Optional extra arguments to pass to k3s installer, wrapped in quotes (e.g. --k3s-extra-args '--node-taint key=value:NoExecute')")
-	command.Flags().String("k3s-version", "", "Optional: set a version to install, overrides k3s-channel")
-	command.Flags().String("k3s-channel", PinnedK3sChannel, "Optional release channel: stable, latest, or i.e. v1.18")
+	command.Flags().String("k3s-extra-args", "", "Additional arguments to pass to k3s installer, wrapped in quotes (e.g. --k3s-extra-args '--node-taint key=value:NoExecute')")
+	command.Flags().String("k3s-version", "", "Set a version to install, overrides k3s-channel")
+	command.Flags().String("k3s-channel", PinnedK3sChannel, "Release channel: stable, latest, or i.e. v1.18")
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 		fmt.Printf("Running: k3sup join\n")

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -6,17 +6,17 @@ import (
 
 type CommandOperator interface {
 	Execute(command string) (CommandRes, error)
+	ExecuteStdio(command string, stream bool) (CommandRes, error)
 }
 
 type ExecOperator struct {
 }
 
-func (ex ExecOperator) Execute(command string) (CommandRes, error) {
-
+func (ex ExecOperator) ExecuteStdio(command string, stream bool) (CommandRes, error) {
 	task := goexecute.ExecTask{
 		Command:     command,
 		Shell:       true,
-		StreamStdio: true,
+		StreamStdio: stream,
 	}
 
 	res, err := task.Execute()
@@ -28,5 +28,8 @@ func (ex ExecOperator) Execute(command string) (CommandRes, error) {
 		StdErr: []byte(res.Stderr),
 		StdOut: []byte(res.Stdout),
 	}, nil
+}
 
+func (ex ExecOperator) Execute(command string) (CommandRes, error) {
+	return ex.ExecuteStdio(command, true)
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Don't print the kubeconfig by default

## Motivation and Context

The kubeconfig file is already written to disk, and when
people are doing live streams or recordings, they may not want
to be printing these secrets on the screen.

Clarifies the usage of the --server flags for embedded etcd.

Adds "context" to the command output for when people are 
doing a merge of contexts.

Clarifies that K3s 1.19 ships with embedded etcd

## How Has This Been Tested?

Tested against a multipass VM using the following:

```
go build && ./k3sup install --user ubuntu --ip 192.168.64.2 --print-config
go build && ./k3sup install --user ubuntu --ip 192.168.64.2
```

Then accessing k3s with the output:

```
export KUBECONFIG=/Users/alex/go/src/github.com/alexellis/k3sup/kubeconfig
kubectl config set-context default
kubectl get node -o wide
```

## Types of changes

Not a breaking change, but this will change the default behaviour
