### PR TITLE
Use correct host when generating kubeconfig file

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -212,7 +212,7 @@ Provide the --local-path flag with --merge if a kubeconfig already exists in som
 				fmt.Printf("stdout: %q", res.StdOut)
 			}
 
-			if err = obtainKubeconfig(operator, getConfigcommand, ip.String(), context, localKubeconfig, merge, printConfig); err != nil {
+			if err = obtainKubeconfig(operator, getConfigcommand, host, context, localKubeconfig, merge, printConfig); err != nil {
 				return err
 			}
 
@@ -270,7 +270,7 @@ Provide the --local-path flag with --merge if a kubeconfig already exists in som
 		if printCommand {
 			fmt.Printf("ssh: %s\n", getConfigcommand)
 		}
-		if err = obtainKubeconfig(operator, getConfigcommand, ip.String(), context, localKubeconfig, merge, printConfig); err != nil {
+		if err = obtainKubeconfig(operator, getConfigcommand, host, context, localKubeconfig, merge, printConfig); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Signed-off-by: Antonin Bas <abas@vmware.com>

## Description

When using '--host' instead of '--ip' with 'k3sup install', the
generated kubeconfig is incorrect as the IP of the server is not
replaced correctly (with the hostname) and instead is left as 127.0.0.1.

Fixes #294

## How Has This Been Tested?

Tested by creating a k3s cluster on EC2.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
