### PR TITLE
Transparently use ssh-agent on linux/darwin

### DIFF
--- a/cmd/join.go
+++ b/cmd/join.go
@@ -133,16 +133,21 @@ func MakeJoin() *cobra.Command {
 		var sshOperator *operator.SSHOperator
 		var initialSSHErr error
 		if runtime.GOOS != "windows" {
-			// Try SSH agent without parsing key files, will succeed if the user
-			// has already added a key to the SSH Agent, or if using a configured
-			// smartcard
-			config := &ssh.ClientConfig{
-				User:            serverUser,
-				Auth:            []ssh.AuthMethod{sshAgentOnly()},
-				HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-			}
 
-			sshOperator, initialSSHErr = operator.NewSSHOperator(address, config)
+			var sshAgentAuthMethod ssh.AuthMethod
+			sshAgentAuthMethod, initialSSHErr = sshAgentOnly()
+			if initialSSHErr == nil {
+				// Try SSH agent without parsing key files, will succeed if the user
+				// has already added a key to the SSH Agent, or if using a configured
+				// smartcard
+				config := &ssh.ClientConfig{
+					User:            serverUser,
+					Auth:            []ssh.AuthMethod{sshAgentAuthMethod},
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+				}
+
+				sshOperator, initialSSHErr = operator.NewSSHOperator(address, config)
+			}
 		} else {
 			initialSSHErr = errors.New("ssh-agent unsupported on windows")
 		}
@@ -242,16 +247,21 @@ func setupAdditionalServer(serverHost, host string, port int, user, sshKeyPath, 
 	var sshOperator *operator.SSHOperator
 	var initialSSHErr error
 	if runtime.GOOS != "windows" {
-		// Try SSH agent without parsing key files, will succeed if the user
-		// has already added a key to the SSH Agent, or if using a configured
-		// smartcard
-		config := &ssh.ClientConfig{
-			User:            user,
-			Auth:            []ssh.AuthMethod{sshAgentOnly()},
-			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		}
 
-		sshOperator, initialSSHErr = operator.NewSSHOperator(address, config)
+		var sshAgentAuthMethod ssh.AuthMethod
+		sshAgentAuthMethod, initialSSHErr = sshAgentOnly()
+		if initialSSHErr == nil {
+			// Try SSH agent without parsing key files, will succeed if the user
+			// has already added a key to the SSH Agent, or if using a configured
+			// smartcard
+			config := &ssh.ClientConfig{
+				User:            user,
+				Auth:            []ssh.AuthMethod{sshAgentAuthMethod},
+				HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+			}
+
+			sshOperator, initialSSHErr = operator.NewSSHOperator(address, config)
+		}
 	} else {
 		initialSSHErr = errors.New("ssh-agent unsupported on windows")
 	}
@@ -322,16 +332,21 @@ func setupAgent(serverHost, host string, port int, user, sshKeyPath, joinToken, 
 	var sshOperator *operator.SSHOperator
 	var initialSSHErr error
 	if runtime.GOOS != "windows" {
-		// Try SSH agent without parsing key files, will succeed if the user
-		// has already added a key to the SSH Agent, or if using a configured
-		// smartcard
-		config := &ssh.ClientConfig{
-			User:            user,
-			Auth:            []ssh.AuthMethod{sshAgentOnly()},
-			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		}
 
-		sshOperator, initialSSHErr = operator.NewSSHOperator(address, config)
+		var sshAgentAuthMethod ssh.AuthMethod
+		sshAgentAuthMethod, initialSSHErr = sshAgentOnly()
+		if initialSSHErr == nil {
+			// Try SSH agent without parsing key files, will succeed if the user
+			// has already added a key to the SSH Agent, or if using a configured
+			// smartcard
+			config := &ssh.ClientConfig{
+				User:            user,
+				Auth:            []ssh.AuthMethod{sshAgentAuthMethod},
+				HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+			}
+
+			sshOperator, initialSSHErr = operator.NewSSHOperator(address, config)
+		}
 	} else {
 		initialSSHErr = errors.New("ssh-agent unsupported on windows")
 	}


### PR DESCRIPTION
## Description
This fixes #311.

Attempt to create the ssh connection using a pre-existing ssh-agent first, this will allow users with pre-configured agents, yubikeys etc on Linux and Darwin to establish ssh connections without resorting to private keys.

If this first connection attempt fails we fall through to the existing key based auth flow.

Note that Windows is not supported in this PR as yubikeys do not currently use the ssh-agent.

*NOTE* this does not include an update to the join command or docs pending an OK on the install implementation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* OSX
  * Using Yubikey, key present in ssh-agent, prompted for key pin, install completes successfully
  * Using private key file (existing flow), install completes successfully
* Windows 10
  * Using private key file (existing flow), install completes successfully

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - Possibly not? 
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
