### PR TITLE
[fix] kubeconfig merge with wrong order

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -369,7 +369,7 @@ func mergeConfigs(localKubeconfigPath, context string, k3sconfig []byte) ([]byte
 	fmt.Printf("Merging with existing kubeconfig at %s\n", localKubeconfigPath)
 
 	// Append KUBECONFIGS in ENV Vars
-	appendKubeConfigENV := fmt.Sprintf("KUBECONFIG=%s:%s", localKubeconfigPath, file.Name())
+	appendKubeConfigENV := fmt.Sprintf("KUBECONFIG=%s:%s", file.Name(), localKubeconfigPath)
 
 	// Merge the two kubeconfigs and read the output into 'data'
 	cmd := exec.Command("kubectl", "config", "view", "--merge", "--flatten")


### PR DESCRIPTION
issue

https://github.com/alexellis/k3sup/issues/316#issuecomment-801608573

## Description

- merge kube config files in wrong order
- reproduced with raw kubectl command

## How Has This Been Tested?

- k3sup install with 3 nodes
- remove k3s
- resetup with 3 nodes, now it works fine

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
