### PR TITLE
Exclude windows compilation from all target on non x86_64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ Version := $(shell git describe --tags --dirty)
 # Version := "dev"
 GitCommit := $(shell git rev-parse HEAD)
 LDFLAGS := "-s -w -X github.com/alexellis/k3sup/cmd.Version=$(Version) -X github.com/alexellis/k3sup/cmd.GitCommit=$(GitCommit)"
+ARCH := $(shell uname -m)
 export GO111MODULE=on
 SOURCE_DIRS = cmd pkg main.go
 
@@ -24,7 +25,9 @@ dist:
 	CGO_ENABLED=0 GOOS=darwin go build -mod=vendor -a -ldflags $(LDFLAGS) -installsuffix cgo -o bin/k3sup-darwin
 	GOARM=6 GOARCH=arm CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -ldflags $(LDFLAGS) -installsuffix cgo -o bin/k3sup-armhf
 	GOARCH=arm64 CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -ldflags $(LDFLAGS) -installsuffix cgo -o bin/k3sup-arm64
+ifeq ($(ARCH), x86_64)
 	GOOS=windows CGO_ENABLED=0 go build -mod=vendor -a -ldflags $(LDFLAGS) -installsuffix cgo -o bin/k3sup.exe
+endif
 
 .PHONY: hash
 hash:


### PR DESCRIPTION
## Description
Exclude windows compilation from `all` target on non x86_64

## Motivation and Context

golang does not support windows on non x86_64 architectures which makes `make all` fail on e.g. aarch64


## How Has This Been Tested?

I have compiled k3sup on x86_64 and aarch64.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
