### PR TITLE
Allow Specific version of K3Sup to be installed

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -15,8 +15,12 @@ export BINLOCATION="/usr/local/bin"
 ###############################
 # Content common across repos #
 ###############################
+if [ ! $VERSION ]  || [ $VERSION = "latest" ]; then 
+  version=$(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep -i "location:" | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
+  else
+  version=$VERSION
+fi
 
-version=$(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep -i "location:" | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
 if [ ! $version ]; then
     echo "Failed while attempting to install $REPO. Please manually install:"
     echo ""


### PR DESCRIPTION
## Description
Allows the user to use the "VERSION" environment variable to change from using 'latest' to the specified version.  If an invalid value is provided, the value is ignored and latest is used anyway.

## Motivation and Context
I wanted to be able to specify a specific version of the K3SUP installer and found there wasn't one.

## How Has This Been Tested?
Executed with no version set -> uses latest.
Executed wtih "latest" set as VERSION -> uses latest.
Executed with "0.8.9" set as VERSION -> uses 0.8.9
Executed with "thisisaninvalidversion" set as VERSION -> uses latest.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [_] I have added tests to cover my changes. (Not sure how to write them...)
- [?] All new and existing tests passed. (Existing pass and manual tests pass.)