### PR TITLE
Add --token to HA external datastore command

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,12 @@ export DATASTORE="mysql://doadmin:80624d3936dfc8d2e80593@tcp(db-mysql-lon1-90578
 
 You can prefix this command with `  ` two spaces, to prevent it being cached in your bash history.
 
+Generate a token used to encrypt data (If you already have a running node this can be retrieved by logging into a running node and looking in `/var/lib/rancher/k3s/server/token`)
+```bash 
+export TOKEN=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 64)
+```
+
+
 * Create three VMs
 
 Imagine we have the following three VMs, two will be servers, and one will be an agent.
@@ -253,13 +259,13 @@ export AGENT1=104.248.137.25
 * Install the first server
 
 ```bash
-k3sup install --user root --ip $SERVER1 --datastore="${DATASTORE}"
+k3sup install --user root --ip $SERVER1 --datastore="${DATASTORE}" --token=${TOKEN}
 ```
 
 * Install the second server
 
 ```bash
-k3sup install --user root --ip $SERVER2 --datastore="${DATASTORE}"
+k3sup install --user root --ip $SERVER2 --datastore="${DATASTORE}" --token=${TOKEN}
 ```
 
 * Join the first agent

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -231,16 +231,18 @@ func Test_makeInstallExec_Datastore(t *testing.T) {
 	flannelIPSec := false
 	k3sNoExtras := false
 	k3sExtraArgs := ""
+	token := "this-token"
 	ip := "127.0.0.1"
 	tlsSAN := "192.168.0.1"
 	got := makeInstallExec(cluster, ip, tlsSAN,
 		k3sExecOptions{
 			Datastore:    datastore,
+			Token:        token,
 			FlannelIPSec: flannelIPSec,
 			NoExtras:     k3sNoExtras,
 			ExtraArgs:    k3sExtraArgs,
 		})
-	want := "INSTALL_K3S_EXEC='server --tls-san 192.168.0.1 --datastore-endpoint mysql://doadmin:show-password@tcp(db-mysql-lon1-40939-do-user-2197152-0.b.db.ondigitalocean.com:25060)/defaultdb'"
+	want := "INSTALL_K3S_EXEC='server --tls-san 192.168.0.1 --datastore-endpoint mysql://doadmin:show-password@tcp(db-mysql-lon1-40939-do-user-2197152-0.b.db.ondigitalocean.com:25060)/defaultdb --token this-token'"
 	if got != want {
 		t.Errorf("want: %q, got: %q", want, got)
 	}
@@ -251,17 +253,19 @@ func Test_makeInstallExec_Datastore_NoExtras(t *testing.T) {
 	datastore := "mysql://doadmin:show-password@tcp(db-mysql-lon1-40939-do-user-2197152-0.b.db.ondigitalocean.com:25060)/defaultdb"
 	flannelIPSec := false
 	k3sNoExtras := true
+	token := "this-token"
 	k3sExtraArgs := ""
 	ip := "raspberrypi.local"
 	tlsSAN := "192.168.0.1"
 	got := makeInstallExec(cluster, ip, tlsSAN,
 		k3sExecOptions{
 			Datastore:    datastore,
+			Token:        token,
 			FlannelIPSec: flannelIPSec,
 			NoExtras:     k3sNoExtras,
 			ExtraArgs:    k3sExtraArgs,
 		})
-	want := "INSTALL_K3S_EXEC='server --tls-san 192.168.0.1 --datastore-endpoint mysql://doadmin:show-password@tcp(db-mysql-lon1-40939-do-user-2197152-0.b.db.ondigitalocean.com:25060)/defaultdb --no-deploy servicelb --no-deploy traefik'"
+	want := "INSTALL_K3S_EXEC='server --tls-san 192.168.0.1 --datastore-endpoint mysql://doadmin:show-password@tcp(db-mysql-lon1-40939-do-user-2197152-0.b.db.ondigitalocean.com:25060)/defaultdb --token this-token --no-deploy servicelb --no-deploy traefik'"
 	if got != want {
 		t.Errorf("want: %q, got: %q", want, got)
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

A token is now required when using an external datastore to encrypt
data. This is auto-generated if not set and therefore the next command
to join a new node failed.

K3sup now required a token when using --datastore arg. 


Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
closes #339 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

deployed on 3 instances using the guide in the readme (updated to include token)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
Breaking change as --datastore commands now also require --token, this matches up with upstream k3s where --token is required


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
