### PR TITLE
fix: merge kubeconfigs on windows

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -51,9 +51,9 @@ func MakeInstall() *cobra.Command {
 		Example: `  k3sup install --ip IP --user USER
 
   k3sup install --local --k3s-version v1.19.7
-  
+
   k3sup install --ip IP --cluster
-  
+
   k3sup install --ip IP --k3s-channel latest
   k3sup install --host HOST --k3s-channel stable
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -401,7 +401,6 @@ func mergeConfigs(localKubeconfigPath, context string, k3sconfig []byte) ([]byte
 	if err != nil {
 		return nil, fmt.Errorf("Could not generate a temporary file to store the kuebeconfig: %s", err)
 	}
-	defer file.Close()
 
 	if err := writeConfig(file.Name(), []byte(k3sconfig), context, true); err != nil {
 		return nil, err
@@ -424,6 +423,11 @@ func mergeConfigs(localKubeconfigPath, context string, k3sconfig []byte) ([]byte
 	data, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("Could not merge kubeconfigs: %s", err)
+	}
+
+	err = file.Close()
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not close temporary kubeconfig file: %s", file.Name())
 	}
 
 	// Remove the temporarily generated file

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -410,7 +410,13 @@ func mergeConfigs(localKubeconfigPath, context string, k3sconfig []byte) ([]byte
 	fmt.Printf("Merging with existing kubeconfig at %s\n", localKubeconfigPath)
 
 	// Append KUBECONFIGS in ENV Vars
-	appendKubeConfigENV := fmt.Sprintf("KUBECONFIG=%s:%s", localKubeconfigPath, file.Name())
+	var joinChar string
+	if runtime.GOOS == "windows" {
+		joinChar = ";"
+	} else {
+		joinChar = ":"
+	}
+	appendKubeConfigENV := fmt.Sprintf("KUBECONFIG=%s%s%s", localKubeconfigPath, joinChar, file.Name())
 
 	// Merge the two kubeconfigs and read the output into 'data'
 	cmd := exec.Command("kubectl", "config", "view", "--merge", "--flatten")

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -352,7 +352,7 @@ func obtainKubeconfig(operator operator.CommandOperator, getConfigcommand, host,
 		fmt.Printf("Result: %s %s\n", string(res.StdOut), string(res.StdErr))
 	}
 
-	absPath, _ := filepath.Abs(localKubeconfig)
+	absPath, _ := filepath.Abs(expandPath(localKubeconfig))
 
 	kubeconfig := rewriteKubeconfig(string(res.StdOut), host, context)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Merging kubeconfigs does not work on Windows. This PR fixes it.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md)) 


Described in https://github.com/alexellis/k3sup/issues/356.


## How Has This Been Tested?
Local execution on windows 10.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
