### PR TITLE
Added instructions for using --server-user

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ export USER=root
 k3sup join --ip $AGENT_IP --server-ip $SERVER_IP --user $USER
 ```
 
+Please note that if you are using different usernames for SSH'ing to the agent and the server that you must provide the username for the server via the `--server-user` parameter.
+
 That's all, so with the above command you can have a two-node cluster up and running, whether that's using VMs on-premises, using Raspberry Pis, 64-bit ARM or even cloud VMs on EC2.
 
 ### Create a multi-master (HA) setup with external SQL
@@ -269,6 +271,8 @@ You can join the agent to either server, the datastore is not required for this 
 ```bash
 k3sup join --user root --server-ip $SERVER1 --ip $AGENT1
 ```
+
+Please note that if you are using different usernames for SSH'ing to the agent and the server that you must provide the username for the server via the `--server-user` parameter.
 
 * Additional steps
 
@@ -621,6 +625,10 @@ The most common problem is that you missed a step, fortunately it's relatively e
 * The K3s agent didn't start. Log in and run `sudo systemctl status k3s-agent`
 * You tried to remove and re-add a server in an etcd cluster and it failed. This is a known issue, see the [K3s issue tracker](https://github.com/k3s-io/k3s/issues).
 * You tried to use an unsupported version of a database for HA. See [this list from Rancher](https://rancher.com/docs/k3s/latest/en/installation/datastore/)
+* Your tried to join a node to the cluster and got an error "ssh: handshake failed". This is probably one of three possibilities:
+  - You did not run `ssh-copy-id`. Try to run it and check if you can log in to the server and the new node without a password prompt using regular `ssh`.
+  - You have an RSA public key. There is an [underlying issue in a Go library](https://github.com/golang/go/issues/39885) which is [referred here](https://github.com/alexellis/k3sup/issues/63). Please provide the additional parameter `--ssh-key ~/.ssh/id_rsa` (or wherever your private key lives) until the issue is resolved.
+  - You are using different usernames for SSH'ing to the server and the node to be added. In that case, playe provide the username for the server via the `--server-user` parameter.
 
 Finally, if everything points to an issue that you can clearly reproduce with k3sup, feel free to open an issue here. To make sure you get a response, fill out the whole template and answer all the questions.
 


### PR DESCRIPTION
There seems to be some recurring issues with users which either have an RSA SSH key or do not know that they need to use the `--server-user` parameter when they are using different usernames on the server and the new node they want to add. I have added some info to the readme that will hopefully clear that up a bit.

Signed-off-by: Carsten Brachem <carsten.brachem@gmail.com>

## Description
Just some additions to the readme regarding the use of the --server-user parameter and adding some common solutions to [this issue](https://github.com/alexellis/k3sup/issues/63) to the troubleshooting section.

## Motivation and Context
- Fixes a part of #63 by explaining a CLI parameter and pointing out an underlying issue with RSA keys
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md)) <-- I have not because the issue already existed


## How Has This Been Tested?
- Just changes in the readme, tested by reviewing the resulting markup document

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Just documentation

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
