### PR TITLE
Use explicit path for SUCCESS_CMD

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -9,8 +9,8 @@ export VERIFY_CHECKSUM=0
 export ALIAS=""
 export OWNER=alexellis
 export REPO=k3sup
-export SUCCESS_CMD="$REPO version"
 export BINLOCATION="/usr/local/bin"
+export SUCCESS_CMD="$BINLOCATION/$REPO version"
 
 ###############################
 # Content common across repos #
@@ -25,7 +25,7 @@ if [ ! $version ]; then
     echo "3. chmod +x ./$REPO"
     echo "4. mv ./$REPO $BINLOCATION"
     if [ -n "$ALIAS_NAME" ]; then
-        echo "5. ln -sf $BINLOCATION/$REPO /usr/local/bin/$ALIAS_NAME"
+        echo "5. ln -sf $BINLOCATION/$REPO $BINLOCATION/$ALIAS_NAME"
     fi
     exit 1
 fi


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
This propagates a change that was initially made in arkade
(https://github.com/alexellis/arkade/pull/685) after it was found
that sudo on CentOS9 was not able to find the new binary in the path
it uses by default.  This led to a poor UX as the binary had been
installed but an error in running SUCCESS_CMD gave the impression
that the installation had failed.  This change adds an explicit
path to SUCCESS_CMD so that it can be found when running through sudo
with a 'secure_path' set.

Also addressed is a future bug where ALIAS_NAME is set.  $BINLOCATION was
only used once in the `ln` command which would lead to a future failure
where ALIAS_NAME is set and the BINLOCATION was not /usr/local/bin.

## Motivation and Context
- [x] I have raised an issue to propose this change 
Relates to https://github.com/alexellis/arkade/issues/683 and https://github.com/alexellis/arkade/pull/685 and specifically https://github.com/alexellis/arkade/pull/685#issuecomment-1118269855 

## How Has This Been Tested?
Since the original issue affected CentOS9 this was tested on CentOS9.

Using current script, noting `main: line 172: k3sup: command not found`:
```
# curl -sLS https://get.k3sup.dev | sudo sh
x86_64
Downloading package https://github.com/alexellis/k3sup/releases/download/0.11.3/k3sup as /tmp/k3sup
Download complete.

Running with sufficient permissions to attempt to move k3sup to /usr/local/bin
New version of k3sup installed to /usr/local/bin
main: line 172: k3sup: command not found

================================================================
  Thanks for choosing k3sup.
  Support the project through GitHub Sponsors

  https://github.com/sponsors/alexellis
================================================================
```

Using proposed change in the branch on my fork:
```
# curl -sLS https://raw.githubusercontent.com/rgee0/k3sup/getDotSh/get.sh | sudo sh
x86_64
Downloading package https://github.com/alexellis/k3sup/releases/download/0.11.3/k3sup as /tmp/k3sup
Download complete.

Running with sufficient permissions to attempt to move k3sup to /usr/local/bin
New version of k3sup installed to /usr/local/bin
 _    _____                 
| | _|___ / ___ _   _ _ __  
| |/ / |_ \/ __| | | | '_ \ 
|   < ___) \__ \ |_| | |_) |
|_|\_\____/|___/\__,_| .__/ 
                     |_|    
Version: 0.11.3
Git Commit: e2bb18116d3686bf53cf40fe0998af7b6c9cf8a6

Give your support to k3sup via GitHub Sponsors:

https://github.com/sponsors/alexellis

================================================================
  Thanks for choosing k3sup.
  Support the project through GitHub Sponsors

  https://github.com/sponsors/alexellis
================================================================
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
