### PR TITLE
Fix: Replace deprecated --no-deploy with --disable causing the installation to fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Other options for `install`:
 * `--merge` - Merge config into existing file instead of overwriting (e.g. to add config to the default kubectl config, use `--local-path ~/.kube/config --merge`).
 * `--context` - default is `default` - set the name of the kubeconfig context.
 * `--ssh-port` - default is `22`, but you can specify an alternative port i.e. `2222`
-* `--k3s-extra-args` - Optional extra arguments to pass to k3s installer, wrapped in quotes, i.e. `--k3s-extra-args '--no-deploy traefik'` or `--k3s-extra-args '--docker'`. For multiple args combine then within single quotes `--k3s-extra-args '--no-deploy traefik --docker'`.
+* `--k3s-extra-args` - Optional extra arguments to pass to k3s installer, wrapped in quotes, i.e. `--k3s-extra-args '--disable traefik'` or `--k3s-extra-args '--docker'`. For multiple args combine then within single quotes `--k3s-extra-args '--disable traefik --docker'`.
 * `--k3s-version` - set the specific version of k3s, i.e. `v1.21.1`
 * `--k3s-channel` - set a specific version of k3s based upon a channel i.e. `stable`
 - `--ipsec` - Enforces the optional extra argument for k3s: `--flannel-backend` option: `ipsec`

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -111,7 +111,7 @@ Provide the --local-path flag with --merge if a kubeconfig already exists in som
 	command.Flags().String("token", "", "the token used to encrypt the datastore, must be the same token for all nodes")
 
 	command.Flags().String("k3s-version", "", "Set a version to install, overrides k3s-channel")
-	command.Flags().String("k3s-extra-args", "", "Additional arguments to pass to k3s installer, wrapped in quotes (e.g. --k3s-extra-args '--no-deploy servicelb')")
+	command.Flags().String("k3s-extra-args", "", "Additional arguments to pass to k3s installer, wrapped in quotes (e.g. --k3s-extra-args '--disable servicelb')")
 	command.Flags().String("k3s-channel", PinnedK3sChannel, "Release channel: stable, latest, or pinned v1.19")
 
 	command.Flags().String("tls-san", "", "Use an additional IP or hostname for the API server")
@@ -586,8 +586,8 @@ func makeInstallExec(cluster bool, host, tlsSAN string, options k3sExecOptions) 
 	}
 
 	if options.NoExtras {
-		extraArgs = append(extraArgs, "--no-deploy servicelb")
-		extraArgs = append(extraArgs, "--no-deploy traefik")
+		extraArgs = append(extraArgs, "--disable servicelb")
+		extraArgs = append(extraArgs, "--disable traefik")
 	}
 
 	extraArgs = append(extraArgs, options.ExtraArgs)

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -255,7 +255,7 @@ func Test_makeInstallExec_Datastore_NoExtras(t *testing.T) {
 			NoExtras:     k3sNoExtras,
 			ExtraArgs:    k3sExtraArgs,
 		})
-	want := "INSTALL_K3S_EXEC='server --tls-san 192.168.0.1 --datastore-endpoint mysql://doadmin:show-password@tcp(db-mysql-lon1-40939-do-user-2197152-0.b.db.ondigitalocean.com:25060)/defaultdb --token this-token --no-deploy servicelb --no-deploy traefik'"
+	want := "INSTALL_K3S_EXEC='server --tls-san 192.168.0.1 --datastore-endpoint mysql://doadmin:show-password@tcp(db-mysql-lon1-40939-do-user-2197152-0.b.db.ondigitalocean.com:25060)/defaultdb --token this-token --disable servicelb --disable traefik'"
 	if got != want {
 		t.Errorf("want: %q, got: %q", want, got)
 	}


### PR DESCRIPTION
## Why do you need this?
k3s installation fails when `--no-extras` is used because of deprecated `--no-deploy`
I replaced `--no-deploy` with `--disable`

## Description
This PR is replacing the deprecated option with the right one


## How Has This Been Tested?
Built k3sup and tested with the right option on Ubuntu node

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
