### PR TITLE
Fix: Version checking for disable vs no-deploy flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Other options for `install`:
 * `--merge` - Merge config into existing file instead of overwriting (e.g. to add config to the default kubectl config, use `--local-path ~/.kube/config --merge`).
 * `--context` - default is `default` - set the name of the kubeconfig context.
 * `--ssh-port` - default is `22`, but you can specify an alternative port i.e. `2222`
-* `--k3s-extra-args` - Optional extra arguments to pass to k3s installer, wrapped in quotes, i.e. `--k3s-extra-args '--no-deploy traefik'` or `--k3s-extra-args '--docker'`. For multiple args combine then within single quotes `--k3s-extra-args '--no-deploy traefik --docker'`.
+* `--k3s-extra-args` - Optional extra arguments to pass to k3s installer, wrapped in quotes, i.e. `--k3s-extra-args '--disable traefik'` or `--k3s-extra-args '--docker'`. For multiple args combine then within single quotes `--k3s-extra-args '--disable traefik --docker'`.
 * `--k3s-version` - set the specific version of k3s, i.e. `v1.21.1`
 * `--k3s-channel` - set a specific version of k3s based upon a channel i.e. `stable`
 - `--ipsec` - Enforces the optional extra argument for k3s: `--flannel-backend` option: `ipsec`

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -139,7 +139,7 @@ func Test_makeInstallExec(t *testing.T) {
 	k3sExtraArgs := ""
 	ip := "raspberrypi.local"
 	tlsSAN := ""
-	got := makeInstallExec(cluster, ip, tlsSAN,
+	got := makeInstallExec(cluster, ip, tlsSAN, "",
 		k3sExecOptions{
 			Datastore:    datastore,
 			FlannelIPSec: flannelIPSec,
@@ -160,7 +160,7 @@ func Test_makeInstallExec_Cluster(t *testing.T) {
 	k3sExtraArgs := ""
 	ip := "127.0.0.1"
 	tlsSAN := ""
-	got := makeInstallExec(cluster, ip, tlsSAN,
+	got := makeInstallExec(cluster, ip, tlsSAN, "",
 		k3sExecOptions{
 			Datastore:    datastore,
 			FlannelIPSec: flannelIPSec,
@@ -181,7 +181,7 @@ func Test_makeInstallExec_SAN(t *testing.T) {
 	k3sExtraArgs := ""
 	ip := "127.0.0.1"
 	tlsSAN := "192.168.0.1"
-	got := makeInstallExec(cluster, ip, tlsSAN,
+	got := makeInstallExec(cluster, ip, tlsSAN, "",
 		k3sExecOptions{
 			Datastore:    datastore,
 			FlannelIPSec: flannelIPSec,
@@ -202,7 +202,7 @@ func Test_makeInstallExec_IPSec(t *testing.T) {
 	k3sExtraArgs := ""
 	ip := "127.0.0.1"
 	tlsSAN := ""
-	got := makeInstallExec(cluster, ip, tlsSAN,
+	got := makeInstallExec(cluster, ip, tlsSAN, "",
 		k3sExecOptions{
 			Datastore:    datastore,
 			FlannelIPSec: flannelIPSec,
@@ -224,7 +224,7 @@ func Test_makeInstallExec_Datastore(t *testing.T) {
 	token := "this-token"
 	ip := "127.0.0.1"
 	tlsSAN := "192.168.0.1"
-	got := makeInstallExec(cluster, ip, tlsSAN,
+	got := makeInstallExec(cluster, ip, tlsSAN, "",
 		k3sExecOptions{
 			Datastore:    datastore,
 			Token:        token,
@@ -247,7 +247,7 @@ func Test_makeInstallExec_Datastore_NoExtras(t *testing.T) {
 	k3sExtraArgs := ""
 	ip := "raspberrypi.local"
 	tlsSAN := "192.168.0.1"
-	got := makeInstallExec(cluster, ip, tlsSAN,
+	got := makeInstallExec(cluster, ip, tlsSAN, "",
 		k3sExecOptions{
 			Datastore:    datastore,
 			Token:        token,
@@ -255,7 +255,7 @@ func Test_makeInstallExec_Datastore_NoExtras(t *testing.T) {
 			NoExtras:     k3sNoExtras,
 			ExtraArgs:    k3sExtraArgs,
 		})
-	want := "INSTALL_K3S_EXEC='server --tls-san 192.168.0.1 --datastore-endpoint mysql://doadmin:show-password@tcp(db-mysql-lon1-40939-do-user-2197152-0.b.db.ondigitalocean.com:25060)/defaultdb --token this-token --no-deploy servicelb --no-deploy traefik'"
+	want := "INSTALL_K3S_EXEC='server --tls-san 192.168.0.1 --datastore-endpoint mysql://doadmin:show-password@tcp(db-mysql-lon1-40939-do-user-2197152-0.b.db.ondigitalocean.com:25060)/defaultdb --token this-token --no-deploy servicelb --disable traefik'"
 	if got != want {
 		t.Errorf("want: %q, got: %q", want, got)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/alexellis/go-execute v0.5.0
+	github.com/hashicorp/go-version v1.6.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/morikuni/aec v1.0.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/alexellis/go-execute v0.5.0 h1:L8kgNlFzNbJov7jrInlaig7i6ZUSz/tYYmqvb8dyD0s=
 github.com/alexellis/go-execute v0.5.0/go.mod h1:AgHTcsCF9wrP0mMVTO8N+lFw1Biy71NybBOk8M+qgy8=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=


### PR DESCRIPTION
Signed-off-by: Brandt Keller <brandt.keller@defenseunicorns.com>

## Are you a GitHub Sponsor?

No

Only sponsors may Pull Requests (PRs), all other PRs (unless previously discussed agreed upon with a maintainer) will be closed without comment.

Check at [https://github.com/sponsors/alexellis](https://github.com/sponsors/alexellis)

<!--- Provide a general summary of the issue in the Title above -->

## Why do you need this?

The use of `--no-extras` is currently broken - as `--no-deploy` now throws a fatal error due to deprecation in `v1.17.4+k3s1`.

This essentially duplicates some of the work done on https://github.com/alexellis/k3sup/pull/394 - but due to responses and some additionally required error checking for maximum compatibility - I wanted to submit another version.

Open to collaborating with others and any feedback.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

https://github.com/alexellis/k3sup/issues/396

If you have no approval from a maintainer, close this PR and raise an issue.

## Description
<!--- Describe your changes in detail -->

Simple conditional for `--no-extras` to establish a default scenario and then a quick version check to look for a specified `--k3s-version` < `v1.17.4+k3s1` where I believe`--no-deploy` was first deprecated in favor of `--disable`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested through the manual execution with `--k3s-version` specified to ensure versions < `v1.17.4+k3s1` use `--no-deploy` and all versions >= `v1.17.4+k3s1` use `--disable` 

Working on understanding the testing more - as some of the testing would require some specific configurations to the target (such as older cgroups implementations). 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
