### PR TITLE
Add IPv6 only cluster docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,31 @@ Now where next? I would recommend my detailed tutorial where I spend time lookin
 
 Try it now: [Will it cluster? K3s on Raspbian](https://blog.alexellis.io/test-drive-k3s-on-raspberry-pi/)
 
+## IPv6 only clusters
+
+You will need to use a proxy to install k3s, because github.com doesn't have a IPv6 address and k3s binaries are hosted there.
+
+[One easy solution](https://danwin1210.de/github-ipv6-proxy.php) to this problem is to add this to your /etc/hosts file:
+
+```
+2a01:4f8:c010:d56::2 github.com
+2a01:4f8:c010:d56::3 api.github.com
+2a01:4f8:c010:d56::4 codeload.github.com
+2a01:4f8:c010:d56::5 objects.githubusercontent.com
+```
+
+Once you proxied your requests for github.com, make sure you bracket the ip, for example [2606:4700:4700::1111], and use `--host` `--server-host`, instead of `--ip` or `--server-ip`.
+
+Example k3sup install on a IPv6 only cluster:
+```sh
+k3sup install --host [2606:4700:4700::1001] --user root --k3s-extra-args '--flannel-ipv6-masq'
+```
+
+Example k3sup join on a IPv6 only cluster:
+```sh
+k3sup join --host [2606:4700:4700::1111] --server-host [2606:4700:4700::1001] --user root
+```
+
 ## Caveats on security
 
 If you are using public cloud, then make sure you see the notes from the Rancher team on setting up a Firewall or Security Group.


### PR DESCRIPTION
Signed-off-by: Carlos Mora

<!--- Provide a general summary of the issue in the Title above -->

## Why do you need this?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

IPv4 VPS are getting expensive, therefore, now VPS are cheaper if you decide to go for the only IPv6 option (10-30% savings).

## Description
This only adds the docs on how to be able to use `k3sup` to spin up IPv6-only clusters.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A full cluster has been created using IPv6-only VPS with no issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
