### PR TITLE
Add plan command node-token command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ kubeconfig
 .idea/
 mc
 /install.sh
+/*.json
+*.txt
+/bootstrap.sh

--- a/cmd/node-token.go
+++ b/cmd/node-token.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/alexellis/k3sup/pkg"
+	ssh "github.com/alexellis/k3sup/pkg/operator"
+
+	"github.com/spf13/cobra"
+)
+
+// MakeNodeToken creates the node-token command
+func MakeNodeToken() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "node-token",
+		Short: "Retrieve the node token from a server",
+		Long: `Retrieve the node token from a server required for a
+server or agent to join the cluster.
+
+` + pkg.SupportMessageShort + `
+`,
+		Example: `  # Get the node token from the server and pipe it to a file
+  k3sup node-token --ip IP --user USER > token.txt
+`,
+		SilenceUsage: true,
+	}
+
+	command.Flags().IP("ip", net.ParseIP("127.0.0.1"), "Public IP of node")
+	command.Flags().String("user", "root", "Username for SSH login")
+
+	command.Flags().String("host", "", "Public hostname of node on which to install agent")
+
+	command.Flags().Bool("local", false, "Use local machine instead of ssh client")
+	command.Flags().String("ssh-key", "~/.ssh/id_rsa", "The ssh key to use for remote login")
+	command.Flags().Int("ssh-port", 22, "The port on which to connect for ssh")
+	command.Flags().Bool("sudo", true, "Use sudo for installation. e.g. set to false when using the root user and no sudo is available.")
+
+	command.Flags().Bool("print-command", false, "Print the command to be executed")
+	command.Flags().String("server-data-dir", "/var/lib/rancher/k3s/", "Override the path used to fetch the node-token from the server")
+
+	command.PreRunE = func(command *cobra.Command, args []string) error {
+		local, err := command.Flags().GetBool("local")
+		if err != nil {
+			return err
+		}
+
+		if !local {
+			_, err = command.Flags().GetString("host")
+			if err != nil {
+				return err
+			}
+
+			if _, err := command.Flags().GetIP("ip"); err != nil {
+				return err
+			}
+
+			if _, err := command.Flags().GetInt("ssh-port"); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	command.RunE = func(command *cobra.Command, args []string) error {
+
+		fmt.Fprintf(os.Stderr, "Fetching: /etc/rancher/k3s/k3s.yaml\n")
+
+		useSudo, err := command.Flags().GetBool("sudo")
+		if err != nil {
+			return err
+		}
+
+		sudoPrefix := ""
+		if useSudo {
+			sudoPrefix = "sudo "
+		}
+
+		local, _ := command.Flags().GetBool("local")
+
+		ip, err := command.Flags().GetIP("ip")
+		if err != nil {
+			return err
+		}
+
+		host, err := command.Flags().GetString("host")
+		if err != nil {
+			return err
+		}
+		if len(host) == 0 {
+			host = ip.String()
+		}
+
+		port, _ := command.Flags().GetInt("ssh-port")
+		user, _ := command.Flags().GetString("user")
+		sshKey, _ := command.Flags().GetString("ssh-key")
+
+		dataDir, _ := command.Flags().GetString("server-data-dir")
+
+		sshKeyPath := expandPath(sshKey)
+		address := fmt.Sprintf("%s:%d", host, port)
+		if !local {
+			fmt.Fprintf(os.Stderr, "Remote: %s\n", address)
+		}
+
+		printCommand := false
+
+		getTokenCommand := fmt.Sprintf("%scat %s\n", sudoPrefix, path.Join(dataDir, "/server/node-token"))
+		if printCommand {
+			fmt.Printf("ssh: %s\n", getTokenCommand)
+		}
+
+		var operator ssh.CommandOperator
+		if local {
+			operator = ssh.ExecOperator{}
+		} else {
+			sshOperator, sshOperatorDone, errored, err := connectOperator(user, address, sshKeyPath)
+			if errored {
+				return err
+			}
+			operator = sshOperator
+
+			if sshOperatorDone != nil {
+				defer sshOperatorDone()
+			}
+		}
+
+		nodeToken, err := obtainNodeToken(operator, getTokenCommand, host)
+		if err != nil {
+			return err
+		}
+
+		if len(nodeToken) == 0 {
+			return fmt.Errorf("no node token found")
+		}
+
+		fmt.Println(nodeToken)
+		return nil
+	}
+
+	return command
+}
+
+func obtainNodeToken(operator ssh.CommandOperator, command, host string) (string, error) {
+	res, err := operator.ExecuteStdio(command, false)
+	if err != nil {
+		return "", fmt.Errorf("error received processing command: %s", err)
+	}
+
+	return strings.TrimSpace(string(res.StdOut)), nil
+
+}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -95,7 +95,7 @@ Input file format, in JSON:
 		for i, host := range hosts {
 			if serversAdded == 0 {
 
-				script += `echo ""Setting up primary server 1
+				script += `echo "Setting up primary server 1"
 `
 
 				script += fmt.Sprintf(`k3sup install --host %s \
@@ -112,7 +112,7 @@ Input file format, in JSON:
 				script += fmt.Sprintf(`
 echo "Fetching the server's node-token into memory"
 
-NODE_TOKEN=$(k3sup node-token --host %s --user %s)
+export NODE_TOKEN=$(k3sup node-token --host %s --user %s)
 `, host.IP, user)
 
 				serversAdded = 1
@@ -120,10 +120,11 @@ NODE_TOKEN=$(k3sup node-token --host %s --user %s)
 			} else if serversAdded < servers {
 				script += fmt.Sprintf("\necho \"Setting up additional server: %d\"\n", serversAdded+1)
 
-				script += fmt.Sprintf(`k3sup join --host %s \
+				script += fmt.Sprintf(`k3sup join \
+--host %s \
 --server-host %s \
 --server \
---node-token-path $NODE_TOKEN \
+--node-token "$NODE_TOKEN" \
 --user %s%s%s
 `, host.IP, primaryServer.IP, user, tlsSanStr, bgStr)
 
@@ -131,9 +132,10 @@ NODE_TOKEN=$(k3sup node-token --host %s --user %s)
 			} else {
 				script += fmt.Sprintf("\necho \"Setting up worker: %d\"\n", (i+1)-serversAdded)
 
-				script += fmt.Sprintf(`k3sup join --host %s \
+				script += fmt.Sprintf(`k3sup join \
+--host %s \
 --server-host %s \
---node-token-path $NODE_TOKEN \
+--node-token "$NODE_TOKEN" \
 --user %s%s
 `, host.IP, primaryServer.IP, user, bgStr)
 			}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/alexellis/k3sup/pkg"
+	"github.com/spf13/cobra"
+)
+
+func MakePlan() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "plan",
+		Short: "Plan an installation of K3s.",
+		Long: `Generate a plan of installation commands for K3s for a HA cluster.
+
+Format:
+
+[{
+	"hostname": "node-1",
+	"ip": "192.168.1.128"
+}]
+
+` + pkg.SupportMessageShort + `
+`,
+		Example: `  Generate an installation script where 3x of the
+  available hosts are dedicated as servers.
+  k3sup plan hosts.json --servers 3
+`,
+		SilenceUsage: true,
+	}
+
+	command.Flags().Int("servers", 3, "Number of servers to use from the pool of hosts")
+	command.Flags().String("local-path", "kubeconfig", "Where to save the kubeconfig file")
+	command.Flags().String("context", "default", "Name of the kubeconfig context to use")
+	command.Flags().String("user", "root", "Username for SSH login")
+
+	command.Flags().String("ssh-key", "", "Path to the private key for SSH login")
+	command.Flags().String("tls-san", "", "SAN for TLS certificates, can be a comma-separated list")
+
+	// Background
+	command.Flags().Bool("background", false, "Run the installation in the background for all agents/nodes after the first server is up")
+
+	command.Flags().Int("limit", 0, "Maximum number of nodes to use from the pool of hosts, 0 for all")
+
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+
+		if len(args) == 0 {
+			return fmt.Errorf("give a path to a JSON file containing a list of hosts")
+		}
+
+		nodeLimit, _ := cmd.Flags().GetInt("limit")
+		name := args[0]
+		data, err := os.ReadFile(name)
+		if err != nil {
+			return err
+		}
+
+		background, _ := cmd.Flags().GetBool("background")
+
+		var hosts []Host
+		if err = json.Unmarshal(data, &hosts); err != nil {
+			return err
+		}
+
+		servers, _ := cmd.Flags().GetInt("servers")
+		kubeconfig, _ := cmd.Flags().GetString("local-path")
+		contextName, _ := cmd.Flags().GetString("context")
+		user, _ := cmd.Flags().GetString("user")
+		tlsSan, _ := cmd.Flags().GetString("tls-san")
+
+		tlsSanStr := ""
+		if len(tlsSan) > 0 {
+			tlsSanStr = fmt.Sprintf(` \
+--tls-san %s`, tlsSan)
+		}
+		// sshKey, _ := cmd.Flags().GetString("ssh-key")
+
+		bgStr := ""
+		if background {
+			bgStr = " &"
+		}
+
+		serversAdded := 0
+		var primaryServer Host
+		script := "#!/bin/sh\n\n"
+
+		for i, host := range hosts {
+			if serversAdded == 0 {
+
+				script += `echo ""Setting up primary server 1
+`
+
+				script += fmt.Sprintf(`k3sup install --host %s \
+--user %s \
+--cluster \
+--local-path %s \
+--context %s%s
+`,
+					host.IP,
+					user,
+					kubeconfig,
+					contextName, tlsSanStr)
+
+				script += fmt.Sprintf(`
+echo "Saving the server's node-token to ./token.txt"
+
+k3sup node-token --host %s \
+--user %s > token.txt
+`, host.IP, user)
+
+				serversAdded = 1
+				primaryServer = host
+			} else if serversAdded < servers {
+				script += fmt.Sprintf("\necho \"Setting up additional server: %d\"\n", serversAdded+1)
+
+				script += fmt.Sprintf(`k3sup join --host %s \
+--server-host %s \
+--server \
+--node-token-path ./token.txt \
+--user %s%s%s
+`, host.IP, primaryServer.IP, user, tlsSanStr, bgStr)
+
+				serversAdded++
+			} else {
+				script += fmt.Sprintf("\necho \"Setting up worker: %d\"\n", (i+1)-serversAdded)
+
+				script += fmt.Sprintf(`k3sup join --host %s \
+--server-host %s \
+--node-token-path ./token.txt \
+--user %s%s
+`, host.IP, primaryServer.IP, user, bgStr)
+			}
+
+			if nodeLimit > 0 && i+1 >= nodeLimit {
+				break
+			}
+		}
+
+		fmt.Printf("%s\n", script)
+
+		return nil
+	}
+
+	return command
+}
+
+type Host struct {
+	Hostname string `json:"hostname"`
+	IP       string `json:"ip"`
+}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -27,11 +27,11 @@ Input file format, in JSON:
 
 ` + pkg.SupportMessageShort + `
 `,
-		Example: `  ## Generate an installation script where 3x of the
-  ## available hosts are dedicated as servers, with a custom user
+		Example: `  # Generate an installation script where 3x of the
+  # available hosts are dedicated as servers, with a custom user
   k3sup plan hosts.json --servers 3 --user ubuntu
 
-  ## Override the TLS SAN, for HA
+  # Override the TLS SAN, for HA
   k3sup plan hosts.json --servers 3 --tls-san $SAN_IP
 `,
 		SilenceUsage: true,
@@ -110,10 +110,9 @@ Input file format, in JSON:
 					contextName, tlsSanStr)
 
 				script += fmt.Sprintf(`
-echo "Saving the server's node-token to ./token.txt"
+echo "Fetching the server's node-token into memory"
 
-k3sup node-token --host %s \
---user %s > token.txt
+NODE_TOKEN=$(k3sup node-token --host %s --user %s)
 `, host.IP, user)
 
 				serversAdded = 1
@@ -124,7 +123,7 @@ k3sup node-token --host %s \
 				script += fmt.Sprintf(`k3sup join --host %s \
 --server-host %s \
 --server \
---node-token-path ./token.txt \
+--node-token-path $NODE_TOKEN \
 --user %s%s%s
 `, host.IP, primaryServer.IP, user, tlsSanStr, bgStr)
 
@@ -134,7 +133,7 @@ k3sup node-token --host %s \
 
 				script += fmt.Sprintf(`k3sup join --host %s \
 --server-host %s \
---node-token-path ./token.txt \
+--node-token-path $NODE_TOKEN \
 --user %s%s
 `, host.IP, primaryServer.IP, user, bgStr)
 			}

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/morikuni/aec v1.0.0
 	github.com/spf13/cobra v1.7.0
 	golang.org/x/crypto v0.13.0
+	golang.org/x/term v0.12.0
 )
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.12.0 // indirect
-	golang.org/x/term v0.12.0 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ func main() {
 	cmdJoin := cmd.MakeJoin()
 	cmdUpdate := cmd.MakeUpdate()
 	cmdReady := cmd.MakeReady()
+	cmdPlan := cmd.MakePlan()
+	cmdNodeToken := cmd.MakeNodeToken()
 
 	printk3supASCIIArt := cmd.PrintK3supASCIIArt
 
@@ -54,6 +56,8 @@ func main() {
 	rootCmd.AddCommand(cmdJoin)
 	rootCmd.AddCommand(cmdUpdate)
 	rootCmd.AddCommand(cmdReady)
+	rootCmd.AddCommand(cmdPlan)
+	rootCmd.AddCommand(cmdNodeToken)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->

Add plan command node-token command

## Description
<!--- Describe your changes in detail -->

* `k3sup plan` is used to read in a list of devices and to generate an installation script for a HA cluster.
* `k3sup node-token` is used by scripts generated by `k3sup plan` to avoid too many SSH connections by each joining node back to the server.
* SSH connection code is moved into a common helper method, instead of getting repeated

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Usage:

devices.json
```json
[{
        "hostname": "node-1",
        "ip": "192.168.1.128"
}]
```

Command:

```
k3sup plan \
  --tls-san $SAN \
  --servers=3 \
  --user ubuntu \
  --background=true/false > bootstrap.sh

chmod +x bootstrap.sh

./bootstrap.sh
```

See testing below:

https://www.youtube.com/watch?v=o4UxRw-Cc8c&feature=youtu.be

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Additional notes required in README..

Future plans:

* Additional flags from `k3sup install/join` should be added to `k3sup plan`
* `--yaml` flag to be added as an option for human-generated inputs to `k3sup plan`