### PR TITLE
Add extra debug log for ssh-agent issues

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -372,7 +372,7 @@ func connectOperator(user string, address string, sshKeyPath string) (*operator.
 
 			sshOperator, initialSSHErr = operator.NewSSHOperator(address, config)
 		} else {
-			return nil, nil, true, fmt.Errorf("unable to load key from ssh-agent: %w", initialSSHErr)
+			fmt.Printf("Unable to load key from ssh-agent: %w", initialSSHErr)
 		}
 	} else {
 		initialSSHErr = errors.New("ssh-agent unsupported on windows")

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -364,7 +364,6 @@ func connectOperator(user string, address string, sshKeyPath string) (*operator.
 		var sshAgentAuthMethod ssh.AuthMethod
 		sshAgentAuthMethod, initialSSHErr = sshAgentOnly()
 		if initialSSHErr == nil {
-
 			config := &ssh.ClientConfig{
 				User:            user,
 				Auth:            []ssh.AuthMethod{sshAgentAuthMethod},
@@ -372,6 +371,8 @@ func connectOperator(user string, address string, sshKeyPath string) (*operator.
 			}
 
 			sshOperator, initialSSHErr = operator.NewSSHOperator(address, config)
+		} else {
+			return nil, nil, true, fmt.Errorf("unable to load key from ssh-agent: %w", initialSSHErr)
 		}
 	} else {
 		initialSSHErr = errors.New("ssh-agent unsupported on windows")


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->

## Why do you need this?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have talked about this in a separate issue ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Description
<!--- Describe your changes in detail -->

I was having issues in https://github.com/alexellis/k3sup/issues/417 specifically with Nushell (`nu`).

In order to diagnose the issue I cloned `k3sup` locally and added a error log statement that helped me diagnose the problem, hence this PR.

It turns out the issue was because I had this in my `config.nu`:

```sh
# Bad
$env.SSH_AUTH_SOCK = "/Users/noah/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"

# Good
$env.SSH_AUTH_SOCK = `/Users/noah/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock`
```

Apparently in Nushell, backticks are the appropriate delimiter for paths that contains spaces in the name.

## How Has This Been Tested?

I tested locally with good and bad Nushell `SSH_AUTH_SOCK` definitions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Logging update (non-breaking change that improves DX)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
