### PR TITLE
Add --server-ssh-key for join command

### DIFF
--- a/cmd/join.go
+++ b/cmd/join.go
@@ -59,6 +59,8 @@ func MakeJoin() *cobra.Command {
 	command.Flags().String("server-user", "root", "Server username for SSH login (Default to --user)")
 
 	command.Flags().String("ssh-key", "~/.ssh/id_rsa", "The ssh key to use for remote login")
+	command.Flags().String("server-ssh-key", "", "The ssh key of an existing k3s server")
+
 	command.Flags().Int("ssh-port", 22, "The port on which to connect for ssh")
 	command.Flags().Int("server-ssh-port", 22, "The port on which to connect to server for ssh (Default to --ssh-port)")
 	command.Flags().Bool("skip-install", false, "Skip the k3s installer")
@@ -154,6 +156,11 @@ func MakeJoin() *cobra.Command {
 		}
 
 		sshKey, _ := command.Flags().GetString("ssh-key")
+		serverSshKey, _ := command.Flags().GetString("server-ssh-key")
+		if len(serverSshKey) == 0 {
+			serverSshKey = sshKey
+		}
+
 		server, err := command.Flags().GetBool("server")
 		if err != nil {
 			return err
@@ -196,11 +203,12 @@ func MakeJoin() *cobra.Command {
 			sudoPrefix = "sudo "
 		}
 		sshKeyPath := expandPath(sshKey)
+		serverSshKeyPath := expandPath(serverSshKey)
 
 		if len(nodeToken) == 0 {
 			address := fmt.Sprintf("%s:%d", serverHost, serverPort)
 
-			sshOperator, sshOperatorDone, errored, err := connectOperator(serverUser, address, sshKeyPath)
+			sshOperator, sshOperatorDone, errored, err := connectOperator(serverUser, address, serverSshKeyPath)
 			if errored {
 				return err
 			}


### PR DESCRIPTION
## Description

Added the `--server-ssh-key` flag to the join command to support the ssh key for the existing k3s server.
If the flag does not exist, we have worked to ensure that it operates as the existing function.

## Why do you need this?
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Was raised by someone else. #404 

## How Has This Been Tested?
```
./k3sup join \
  --ip $HA_IP \
  --user $HA_USER \
  --server \
  --server-ip $SERVER_IP \
  --server-user $SERVER_USER \
  --server-ssh-key $SERVER_SSH_KEY_PATH \
  --ssh-key $SSH_KEY_PATH
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
