### PR TITLE
Add --no-extra flag to join command

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,23 @@ paprika-gregory   Ready    master   8m27s   v1.19.2-k3s
 cave-sensor       Ready    master   27m     v1.19.2-k3s
 ```
 
+If you used `--no-extras` on the initial installation you will also need to provide it on each join:
+
+```sh
+export USER=root
+export SERVER_IP=192.168.0.100
+export NEXT_SERVER_IP=192.168.0.101
+
+k3sup join \
+  --ip $NEXT_SERVER_IP \
+  --user $USER \
+  --server-user $USER \
+  --server-ip $SERVER_IP \
+  --server \
+  --no-extras \
+  --k3s-version v1.19.1+k3s1
+```
+
 ### 👨‍💻 Micro-tutorial for Raspberry Pi (2, 3, or 4) 🥧
 
 In a few moments you will have Kubernetes up and running on your Raspberry Pi 2, 3 or 4. Stand by for the fastest possible install. At the end you will have a KUBECONFIG file on your local computer that you can use to access your cluster remotely.


### PR DESCRIPTION
## Why do you need this?
It was found that when joining servers to a cluster any additional servers would not honour the `--no-extras` flag used with the install command.

It is necessary, therefore, for the flag to be added to `join` and only be applied in situations where `--server` has been provided.

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Although closed, #408 refers

## Description

Adds `--no-extras` to the join command such that it will work when used with `--server`.

## How Has This Been Tested?

### Add new flag without --server
```
$ ./k3sup-darwin join \             
  --ip $SERVER_IP_2 \
  --user $USER \
  --server-user $USER \
  --server-ip $SERVER_IP \
  --no-extras --print-command

Error: --no-extras can only be used with --server
```
### Add new flag with --server
```
 $ ./k3sup-darwin join \
  --ip $SERVER_IP_2 \
  --user $USER \
  --server-user $USER \
  --server-ip $SERVER_IP \
  --no-extras --print-command --server

Running: k3sup join
Joining 209.97.141.169 => 138.68.158.53
ssh: sudo cat /var/lib/rancher/k3s/server/node-token

Received node-token from 138.68.158.53.. ok.
ssh: curl -sfL https://get.k3s.io | K3S_URL='https://138.68.158.53:6443'  \
K3S_TOKEN='<token>::server:<alphanumeric>' \
INSTALL_K3S_CHANNEL='stable' \
INSTALL_K3S_EXEC='server --server https://138.68.158.53:6443' \
sh -s -  --disable servicelb --disable traefik
```
Note the addition of ` --disable servicelb --disable traefik` to the output command

### With `--tls-san` added as this was in the area of change:
```
$ ./k3sup-darwin join \
  --ip $SERVER_IP_2 \
  --user $USER \
  --server-user $USER \
  --server-ip $SERVER_IP \
  --no-extras --print-command --server  --tls-san 127.0.0.1
Running: k3sup join
Joining 209.97.141.169 => 138.68.158.53
ssh: sudo cat /var/lib/rancher/k3s/server/node-token

Received node-token from 138.68.158.53.. ok.
ssh: curl -sfL https://get.k3s.io | K3S_URL='https://138.68.158.53:6443' K3S_TOKEN='<alphanumeric>::server:<alphanumeric>' INSTALL_K3S_CHANNEL='stable' INSTALL_K3S_EXEC='server --server https://138.68.158.53:6443 --tls-san 127.0.0.1' sh -s -  --disable servicelb --disable traefik
```
### With `--tls-san` and without `--server`:
```
./k3sup-darwin join \
  --ip $SERVER_IP_2 \
  --user $USER \
  --server-user $USER \
  --server-ip $SERVER_IP \
  --print-command  --tls-san 127.0.0.1 
Error: --tls-san can only be used with --server
```
Demonstrates previous behaviour unchanged

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
