### PR TITLE
fix example and make it valid JSON

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -20,9 +20,11 @@ Input file format, in JSON:
 
 [{
 	"hostname": "node-1",
-	"ip": "192.168.128.100",
+	"ip": "192.168.128.100"
+},
+{
 	"hostname": "node-2",
-	"ip": "192.168.128.101",
+	"ip": "192.168.128.101"
 }]
 
 ` + pkg.SupportMessageShort + `


### PR DESCRIPTION
Fix the given JSON in the long command help text and show a valid
JSON document.

resolves #432
