### PR TITLE
Update upload-assets action to 0.5.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Make all
         run: make all
       - name: Upload release binaries
-        uses: alexellis/upload-assets@0.4.1
+        uses: alexellis/upload-assets@0.5.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Why do you need this?

## Description
This change updates `alexellis/upload-assets` from `0.4.1` to `0.5.0` in `.github/workflows/publish.yaml`.

## How Has This Been Tested?
This change only updates the GitHub Actions release upload action version in `.github/workflows/publish.yaml`.

The action has no breaking changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
